### PR TITLE
Precise Manipulation

### DIFF
--- a/lua/autorun/client/ragdollmover_client.lua
+++ b/lua/autorun/client/ragdollmover_client.lua
@@ -40,6 +40,15 @@ end
 
 hook.Add("InitPostEntity", "rgmClientSetup", function()
 	local pl = LocalPlayer()
+	local BindRot, BindScale = GetConVar("ragdollmover_rotatebutton"):GetInt(), GetConVar("ragdollmover_scalebutton"):GetInt()
 
 	pl.rgmSyncClient = SyncOneClient
+
+	net.Start("rgmSetToggleRot")
+	net.WriteInt(BindRot, 32)
+	net.SendToServer()
+
+	net.Start("rgmSetToggleScale")
+	net.WriteInt(BindScale, 32)
+	net.SendToServer()
 end)

--- a/lua/autorun/ragdollmover_meta.lua
+++ b/lua/autorun/ragdollmover_meta.lua
@@ -3,6 +3,8 @@
 	Other functionality that isn't part of the rgm module.
 ]]
 
+resource.AddSingleFile("resource/localization/en/ragdollmover_tools.properties")
+
 local TYPE_ENTITY	 = 1
 local TYPE_NUMBER	 = 2
 local TYPE_VECTOR	 = 3

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -245,6 +245,8 @@ end)
 end
 
 concommand.Add("ragdollmover_resetroot", function(pl)
+	if not IsValid(pl.rgm.Entity) then return end
+
 	RGMGetBone(pl, pl.rgm.Entity, 0)
 	pl:rgmSync()
 

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -27,8 +27,21 @@ tool.ragdollmover.bindrot=Rotate toggle button
 tool.ragdollmover.bindscale=Scale toggle button
 
 tool.ragdollmover.bonemanpanel=Bone Manipulation
+tool.ragdollmover.bonemanip=Precise Non-Physics Manipulation
+
+tool.ragdollmover.pos1=Pos X
+tool.ragdollmover.pos2=Pos Y
+tool.ragdollmover.pos3=Pos Z
+tool.ragdollmover.rot1=Pitch
+tool.ragdollmover.rot2=Yaw
+tool.ragdollmover.rot3=Roll
+tool.ragdollmover.scale1=Scale X
+tool.ragdollmover.scale2=Scale Y
+tool.ragdollmover.scale3=Scale Z
+
 tool.ragdollmover.resetbone=Reset Non-Physics Bone
 tool.ragdollmover.resetscale=Reset Bone Scale
+tool.ragdollmover.scalezero=Scale Bone to Zero
 tool.ragdollmover.lockpos=Lock PhysBone Position
 tool.ragdollmover.unlockpos=Unlock PhysBone Position
 tool.ragdollmover.lockang=Lock PhysBone Rotation


### PR DESCRIPTION
New features:
- Added button to scale selected bone to 0
- Added "Precise Nonphysics Manipulation" tab that allows to manipulate nonphysical bone properties through sliders

Bugfixes:
- Fixed issue with not being able to switch gizmo modes
- Fixed issue with server not sending english language resource file to clients that don't have ragdoll mover installed
- Fixed lua error that was popping up when trying to reset selected bone to root (through reloading) when no entity was selected
- Bone manipulation is now done serverside, so info with your changes like resetting bone position and rotation will be sent to other clients