### PR TITLE
Fixed issue with IK rigs on 64 bit branch of GMod

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -362,7 +362,7 @@ function FindKnee(pHip,pAnkle,fThigh,fShin,vKneeDir)
 	local vB = pAnkle-pHip
     local LB = vB:Length()
     local aa = (LB*LB+fThigh*fThigh-fShin*fShin)/2/LB
-    local bb = math.sqrt(fThigh*fThigh-aa*aa)
+    local bb = math.sqrt(math.abs(fThigh*fThigh-aa*aa))
     local vF = vB:Cross(vKneeDir:Cross(vB))
 	vB:Normalize()
 	vF:Normalize()


### PR DESCRIPTION
64 bit branch was too good at maths, so it was getting very small negative number in calculations where there was supposed to be no negative numbers (extracting root of a number)