### PR TITLE
Adjusted filter for picking up parented/bonemerged entities

### DIFF
--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -283,10 +283,9 @@ local function rgmFindEntityChildren(parent)
 		table.insert(children, parent.AttachedEntity)
 	end
 	for k, ent in pairs(parent:GetChildren()) do
-		if !IsValid(ent) then continue end
-		if ent:GetClass() == "ent_bonemerged" then
-			table.insert(children, ent)
-		end
+		if not IsValid(ent) then continue end
+
+		table.insert(children, ent)
 	end
 
 	return children
@@ -984,7 +983,7 @@ local function RGMBuildBoneMenu(ent, bonepanel)
 		net.WriteEntity(ent)
 	net.SendToServer()
 
-	if ent:GetClass() == "ent_bonemerged" then
+	if ent:IsEffectActive(EF_BONEMERGE) then
 		net.Start("rgmAskForParented")
 			net.WriteEntity(ent)
 		net.SendToServer()

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -280,7 +280,7 @@ local function rgmFindEntityChildren(parent)
 	local children = {}
 
 	for k, ent in pairs(parent:GetChildren()) do
-		if not IsValid(ent) or ent:IsWorld() or not isstring(ent:GetModel()) then continue end
+		if not IsValid(ent) or ent:IsWorld() or ent:IsConstraint() or not isstring(ent:GetModel()) or not util.IsValidModel(ent:GetModel()) then continue end
 
 		table.insert(children, ent)
 	end
@@ -1003,6 +1003,8 @@ local function RGMBuildEntMenu(parent, children, entpanel)
 	end
 
 	for k, v in ipairs(children) do
+		if not IsValid(v) or not isstring(v:GetModel()) then continue end
+
 		entnodes[v] = entnodes[parent]:AddNode(GetModelName(v))
 
 		entnodes[v].DoClick = function()

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -279,9 +279,6 @@ end
 local function rgmFindEntityChildren(parent)
 	local children = {}
 
-	if parent:GetClass() == "prop_effect" and IsValid(parent.AttachedEntity) then
-		table.insert(children, parent.AttachedEntity)
-	end
 	for k, ent in pairs(parent:GetChildren()) do
 		if not IsValid(ent) then continue end
 

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -280,7 +280,7 @@ local function rgmFindEntityChildren(parent)
 	local children = {}
 
 	for k, ent in pairs(parent:GetChildren()) do
-		if not IsValid(ent) then continue end
+		if not IsValid(ent) or ent:IsWorld() or not isstring(ent:GetModel()) then continue end
 
 		table.insert(children, ent)
 	end


### PR DESCRIPTION
Ragdoll mover now would be able to detect and select parented/bonemerged entities from other tools like multi parent or composite bone tool rather than just easy bonemerge and prop_effect's