### PR TITLE
Small enhancements

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -525,8 +525,8 @@ function DrawEntName(ent)
 	local pos
 
 	if name == "prop_ragdoll" then
-		local obj = ent:GetPhysicsObjectNum(0)
-		pos = obj:GetPos()
+		pos = ent:GetBonePosition(0)
+		if not pos then pos = ent:GetPos() end
 	elseif IsValid(ent:GetParent()) then
 		local parent = ent:GetParent()
 		pos = parent:LocalToWorld(ent:GetLocalPos())

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -235,7 +235,9 @@ function ENT:Think()
 	local scale = pl.rgm.Scale or false
 	local offset, offsetlocal = pl.rgm.GizmoOffset, self.localizedoffset
 
-	if pl.rgm.IsPhysBone then
+	if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not (ent:GetClass() == "prop_ragdoll") then
+		pos = ent:GetParent():LocalToWorld(ent:GetLocalPos())
+	elseif pl.rgm.IsPhysBone then
 
 		local physobj = ent:GetPhysicsObjectNum(bone)
 		if physobj == nil then return end
@@ -253,7 +255,9 @@ function ENT:Think()
 			pos = pl.rgm.GizmoPos
 		end
 	end
-	if pl.rgm.IsPhysBone and not scale then
+	if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not (ent:GetClass() == "prop_ragdoll") and not scale then
+		ang = ent:GetParent():LocalToWorldAngles(ent:GetLocalAngles())
+	elseif pl.rgm.IsPhysBone and not scale then
 
 		local physobj = ent:GetPhysicsObjectNum(bone)
 		if physobj == nil then return end
@@ -306,7 +310,7 @@ function ENT:Think()
 	if not pl.rgm.Moving then -- Prevent whole thing from rotating when we do localized rotation - needed for proper angle reading
 		if localstate or scale or not pl.rgm.IsPhysBone then -- Non phys bones don't go well with world coordinates. Well, I didn't make them to behave with those
 			self:SetAngles(ang or Angle(0,0,0))
-			if (ent:GetClass() == "prop_ragdoll" or (ent:GetClass() == "prop_dynamic" and pl.rgm.ParentEntity:GetClass() == "prop_effect") or ent:GetClass() == "ent_bonemerged") and (not pl.rgm.IsPhysBone) then -- those things are meant to work for nonphysical bones of any entity, but man i can't figure out how to do that as GetBonePosition returns angles differently for ragdolls and any other entity. please help
+			if (ent:GetClass() == "prop_ragdoll" or ent:GetClass() == "prop_dynamic" or ent:GetClass() == "ent_bonemerged") and (not pl.rgm.IsPhysBone) then
 				self.DiscP:SetLocalAngles(Angle(0, 90 + ent:GetManipulateBoneAngles(bone).y, 0)) -- Pitch follows Yaw angles
 				self.DiscR:SetLocalAngles(Angle(0 + ent:GetManipulateBoneAngles(bone).x, 0 + ent:GetManipulateBoneAngles(bone).y, 0)) -- Roll follows Pitch and Yaw angles
 			else

--- a/lua/entities/rgm_axis_arrow/init.lua
+++ b/lua/entities/rgm_axis_arrow/init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, isphys, StartGrab, NPhysPos)
+function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, StartGrab, NPhysPos)
 	local intersect = self:GetGrabPos(eyepos,eyeang,ppos)
 	local localized = self:WorldToLocal(intersect)
 	local axis = self:GetParent()
@@ -14,19 +14,24 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, is
 	end
 	local pos, ang
 
-	if isphys then
-		local _a
+	if movetype == 1 then
 		local obj = ent:GetPhysicsObjectNum(bone)
 		localized = Vector(localized.x,0,0)
 		intersect = self:LocalToWorld(localized)
 		ang = obj:GetAngles()
-		pos,_a = LocalToWorld(Vector(offpos.x,0,0),Angle(0,0,0),intersect - offset,self:GetAngles())
-	else
+		pos = LocalToWorld(Vector(offpos.x,0,0),Angle(0,0,0),intersect - offset,self:GetAngles())
+	elseif movetype == 2 then
 		pos = ent:GetManipulateBonePosition(bone)
 		localized = Vector(localized.x - StartGrab.x,0,0)
 		local posadd = NPhysPos[self.axistype] + localized.x
 		ang = ent:GetManipulateBoneAngles(bone)
 		pos[self.axistype] = posadd
+	elseif movetype == 0 then
+		localized = Vector(localized.x,0,0)
+		intersect = self:LocalToWorld(localized)
+		ang = ent:GetLocalAngles()
+		pos = LocalToWorld(Vector(offpos.x,0,0),Angle(0,0,0),intersect - offset, self:GetAngles())
+		pos = ent:GetParent():WorldToLocal(pos)
 	end
 	return pos,ang
 end

--- a/lua/entities/rgm_axis_scale_arrow/init.lua
+++ b/lua/entities/rgm_axis_scale_arrow/init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, isphys, StartGrab, garbage, garbage, NPhysScale)
+function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, StartGrab, garbage, garbage, NPhysScale)
 	local intersect = self:GetGrabPos(eyepos,eyeang,ppos)
 	local localized = self:WorldToLocal(intersect)
 	local pos, ang

--- a/lua/entities/rgm_axis_scale_side/init.lua
+++ b/lua/entities/rgm_axis_scale_side/init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, isphys, startGrab, garbage, garbage, NPhysScale)
+function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, startGrab, garbage, garbage, NPhysScale)
 	local intersect = self:GetGrabPos(eyepos,eyeang,ppos,pnorm)
 	local pos, ang
 	local pl = self:GetParent().Owner

--- a/lua/entities/rgm_axis_side/init.lua
+++ b/lua/entities/rgm_axis_side/init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, isphys, startGrab, NPhysPos)
+function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, startGrab, NPhysPos)
 	local intersect = self:GetGrabPos(eyepos,eyeang,ppos,pnorm)
 	local axis = self:GetParent()
 	local offset = axis.Owner.rgm.GizmoOffset
@@ -14,11 +14,11 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, is
 	local pos, ang
 	local pl = self:GetParent().Owner
 
-	if isphys then
+	if movetype == 1 then
 		local obj = ent:GetPhysicsObjectNum(bone)
 		ang = obj:GetAngles()
 		pos = LocalToWorld(offpos,Angle(0,0,0),intersect - offset,self:GetAngles())
-	else
+	elseif movetype == 2 then
 		local localized, startmove, finalpos, boneang
 		if ent:GetBoneParent(bone) ~= -1 then
 			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
@@ -37,6 +37,10 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, is
 		finalpos = NPhysPos + localized
 		ang = ent:GetManipulateBoneAngles(bone)
 		pos = finalpos
+	elseif movetype == 0 then
+		ang = ent:GetLocalAngles()
+		pos = LocalToWorld(offpos,Angle(0,0,0),intersect - offset,self:GetAngles())
+		pos = ent:GetParent():WorldToLocal(pos)
 	end
 
 	return pos,ang

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -55,13 +55,25 @@ tool.ragdollmover.scale1=Scale X
 tool.ragdollmover.scale2=Scale Y
 tool.ragdollmover.scale3=Scale Z
 
-tool.ragdollmover.resetbone=Reset Non-Physics Bone
-tool.ragdollmover.resetscale=Reset Bone Scale
-tool.ragdollmover.scalezero=Scale Bone to Zero
-tool.ragdollmover.lockpos=Lock PhysBone Position
-tool.ragdollmover.unlockpos=Unlock PhysBone Position
-tool.ragdollmover.lockang=Lock PhysBone Rotation
-tool.ragdollmover.unlockang=Unlock PhysBone Rotation
+tool.ragdollmover.resetmenu=Reset
+tool.ragdollmover.resetpos=Position
+tool.ragdollmover.resetrot=Rotation
+tool.ragdollmover.resetscale=Scale
+tool.ragdollmover.reset=All
+tool.ragdollmover.resetposchildren=+Children Position
+tool.ragdollmover.resetrotchildren=+Children Rotation
+tool.ragdollmover.resetscalechildren=+Children Scale
+tool.ragdollmover.resetchildren=+Children All
+tool.ragdollmover.scalezero=Scale to Zero
+tool.ragdollmover.bone=Bone
+tool.ragdollmover.bonechildren=Bone + Children
+
+tool.ragdollmover.lockpos=Lock Position
+tool.ragdollmover.unlockpos=Unlock Position
+tool.ragdollmover.lockang=Lock Rotation
+tool.ragdollmover.unlockang=Unlock Rotation
+
+tool.ragdollmover.putgizmopos=Put Gizmo offset here
 
 tool.ragdollmover.bonelist=Bone List
 tool.ragdollmover.entchildren=Entity Children

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -37,6 +37,7 @@ tool.ragdollmover.unfreeze=Unfreeze on release.
 tool.ragdollmover.unfreezetip=Unfreeze bones that were unfrozen before grabbing the ragdoll.
 tool.ragdollmover.disablefilter=Disable entity filter.
 tool.ragdollmover.disablefiltertip=Disable entity filter to select ANY entity. CAUTION - may be buggy
+tool.ragdollmover.drawskeleton=Draw Skeleton
 tool.ragdollmover.updaterate=Tool update rate.
 
 tool.ragdollmover.bindrot=Rotate toggle button

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -55,6 +55,8 @@ tool.ragdollmover.scale1=Scale X
 tool.ragdollmover.scale2=Scale Y
 tool.ragdollmover.scale3=Scale Z
 
+tool.ragdollmover.scalechildren=Scale children bones
+
 tool.ragdollmover.resetmenu=Reset
 tool.ragdollmover.resetpos=Position
 tool.ragdollmover.resetrot=Rotation
@@ -76,6 +78,9 @@ tool.ragdollmover.unlockang=Unlock Rotation
 tool.ragdollmover.putgizmopos=Put Gizmo offset here
 
 tool.ragdollmover.bonelist=Bone List
+tool.ragdollmover.listshowall=All
+tool.ragdollmover.listshowphys=Phys
+tool.ragdollmover.listshownonphys=Nonphys
 tool.ragdollmover.entchildren=Entity Children
 
 tool.ragdollmover.physbone=Physical Bone


### PR DESCRIPTION
- Cleaned up the script a bit

- Fixed issue with nonphysical bones rotating to 180 degrees when selecting them from the bonetree
- Bone manipulation sliders will now get updated when letting go of the gizmos
- Now pressing R or using ragdollmover_resetroot console command will switch between the root bone of an entity and the last selected bone. This still will consider nonphysical bones with ID 0 as "root", though, but ragdolls like that are rare, I think.

- Removed buttons for manipulating bones and moved them into bone tree right click menus
- "Reset position and angles" is now separated into resetting position and resetting rotation buttons
- Nonphysical bone manipulations now also got variants that apply their function to all children of a bone, for example like scaling whole arm of a ragdoll to 0, or reset its scale
- Added option to scale children bones of the selected bone with it

- Children entities tab will now show children of children and nest them
- Added possibility to move parented props (As was requested by kuma7)

- Added buttons that switch bonetree to only show physical or nonphysical bones, or show all bones, which will be applied by default when selecting a new entity (root bones will show in the tree regardless of nonphysical bones being shown)

- Added functionality that draws lines towards child and parent bones of currently hovered bone
- Hovering over name labels for child entities will now show origins of those entities in game
- Added an option to draw whole skeleton of currently selected entity