### PR TITLE
Movement upgrade

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -217,7 +217,7 @@ function GetPhysBoneParent(ent,bone)
 			return parent
 		end
 		i = i + 1
-		if i > 256 then
+		if i > 512 then
 			cont = true
 		end
 	end
@@ -593,8 +593,11 @@ end
 
 local COLOR_RGMGREEN = Color(0,200,0,255)
 
-function DrawBoneName(ent,bone)
-	local name = ent:GetBoneName(bone)
+function DrawBoneName(ent,bone,name)
+	if not name then
+		name = ent:GetBoneName(bone)
+	end
+
 	local _pos = ent:GetBonePosition(bone)
 	if not _pos then
 		_pos = ent:GetPos()

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -270,7 +270,7 @@ function GetOffsetTable(tool,ent,rotate, bonelocks, entlocks)
 			local pos2,ang2 = obj2:GetPos(),obj2:GetAngles()
 			local pos3,ang3 = WorldToLocal(pos1,ang1,pos2,ang2)
 			local mov = obj1:IsMoveable()
-			RTable[pb] = {pos = pos3,ang = ang3,moving = mov,parent = parent}
+			RTable[pb] = {pos = pos3,ang = ang3,moving = mov,parent = parent, lock = bonelocks[pb] and true or nil}
 			local iktable = IsIKBone(tool,ent,pb)
 			if iktable then
 				RTable[pb].isik = true
@@ -378,7 +378,7 @@ local function SetBoneOffsets(tool, ent,ostable,sbone, rlocks, plocks)
 			end
 
 			local footdata = ostable[v.foot]
-			if footdata ~= nil and (footdata.parent ~= v.knee and footdata.parent ~= v.hip) and not RTable[footdata.parent] then 
+			if footdata ~= nil and (footdata.parent ~= v.knee and footdata.parent ~= v.hip) and not RTable[footdata.parent] and footdata.lock then 
 				RecursiveSetParent(ostable, sbone, rlocks, plocks, RTable, footdata.parent)
 			end
 
@@ -488,7 +488,7 @@ function ProcessIK(ent,IKTable,sbone,RT,footlock)
 	local AnklePos,AnkleAng
 	if IKTable.foot == sbone.b then
 		AnklePos,AnkleAng = sbone.p,sbone.a
-	elseif footlock ~= nil and IKTable.knee ~= footlock.parent and IKTable.hip ~= footlock.parent then
+	elseif footlock ~= nil and footlock.lock and IKTable.knee ~= footlock.parent and IKTable.hip ~= footlock.parent then
 		AnklePos,AnkleAng = LocalToWorld(footlock.pos, footlock.ang, RT[footlock.parent].pos, RT[footlock.parent].ang)
 	else
 		AnklePos,AnkleAng = footpos*1,footang*1

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -479,9 +479,9 @@ function ProcessIK(ent,IKTable,sbone,RT,footlock)
 
 	if IKTable.ikhipparent then
 		obj = RT[IKTable.ikhipparent]
-		hpos,hang = LocalToWorld(hippos,Angle(0,0,0),obj.pos,obj.ang)
+		hpos,hang = LocalToWorld(hippos,angle_zero,obj.pos,obj.ang)
 	else
-		hpos,hang = LocalToWorld(hippos,Angle(0,0,0),Vector(0,0,0), Angle(0,0,0))
+		hpos,hang = LocalToWorld(hippos,angle_zero,vector_origin, angle_zero)
 	end
 	local HipPos = hpos*1
 
@@ -539,8 +539,8 @@ function SetAngleOffset(ent,pos,ang,ang2,offang)
 	local _p,_a = WorldToLocal(pos,ang2,pos,ang)
 	_a.p = 0
 	_a.y = 0
-	_p,_a = LocalToWorld(Vector(0,0,0),_a,pos,ang)
-	_p,_a = LocalToWorld(Vector(0,0,0),offang,pos,_a)
+	_p,_a = LocalToWorld(vector_origin,_a,pos,ang)
+	_p,_a = LocalToWorld(vector_origin,offang,pos,_a)
 	return _a
 end
 
@@ -585,6 +585,8 @@ function IsIKBone(tool,ent,bone)
 	return false
 end
 
+local COLOR_RGMGREEN = Color(0,200,0,255)
+
 function DrawBoneName(ent,bone)
 	local name = ent:GetBoneName(bone)
 	local _pos = ent:GetBonePosition(bone)
@@ -593,8 +595,8 @@ function DrawBoneName(ent,bone)
 	end
 	_pos = _pos:ToScreen()
 	local textpos = {x = _pos.x+5,y = _pos.y-5}
-	surface.DrawCircle(_pos.x,_pos.y,3.5,Color(0,200,0,255))
-	draw.SimpleText(name,"Default",textpos.x,textpos.y,Color(0,200,0,255),TEXT_ALIGN_LEFT,TEXT_ALIGN_BOTTOM)
+	surface.DrawCircle(_pos.x,_pos.y,3.5,COLOR_RGMGREEN)
+	draw.SimpleText(name,"Default",textpos.x,textpos.y,COLOR_RGMGREEN,TEXT_ALIGN_LEFT,TEXT_ALIGN_BOTTOM)
 end
 
 function DrawEntName(ent)
@@ -613,8 +615,8 @@ function DrawEntName(ent)
 
 	pos = pos:ToScreen()
 	local textpos = { x = pos.x+5, y = pos.y-5 }
-	surface.DrawCircle(pos.x, pos.y, 3.5, Color(0, 200, 0, 255))
-	draw.SimpleText(name,"Default",textpos.x,textpos.y,Color(0,200,0,255),TEXT_ALIGN_LEFT,TEXT_ALIGN_BOTTOM)
+	surface.DrawCircle(pos.x, pos.y, 3.5, COLOR_RGMGREEN)
+	draw.SimpleText(name,"Default",textpos.x,textpos.y,COLOR_RGMGREEN,TEXT_ALIGN_LEFT,TEXT_ALIGN_BOTTOM)
 end
 
 function DrawBoneConnections(ent, bone)
@@ -652,7 +654,7 @@ local function DrawRecursiveBones(ent, bone)
 		surface.SetDrawColor( 255, 255, 255, 255 )
 		surface.DrawLine(mainpos.x, mainpos.y, pos.x, pos.y)
 		DrawRecursiveBones(ent, boneid)
-		surface.DrawCircle(pos.x, pos.y, 2.5, Color(0, 200, 0, 255))
+		surface.DrawCircle(pos.x, pos.y, 2.5, COLOR_RGMGREEN)
 	end
 end
 
@@ -670,7 +672,7 @@ function DrawSkeleton(ent)
 			DrawRecursiveBones(ent, v)
 
 			pos = pos:ToScreen()
-			surface.DrawCircle(pos.x, pos.y, 2.5, Color(0, 200, 0, 255))
+			surface.DrawCircle(pos.x, pos.y, 2.5, COLOR_RGMGREEN)
 		end
 	end
 

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -372,7 +372,7 @@ local function SetBoneOffsets(tool, ent,ostable,sbone, rlocks, plocks)
 	end
 
 	for k,v in pairs(ent.rgmIKChains) do
-		if tobool(tool:GetClientNumber(DefIKnames[v.type],0)) then
+		if tool:GetClientBool(DefIKnames[v.type]) then
 			if v.ikhipparent then
 				if not RTable[v.ikhipparent] then RecursiveSetParent(ostable, sbone, rlocks, plocks, RTable, v.ikhipparent) end
 			end
@@ -388,7 +388,7 @@ local function SetBoneOffsets(tool, ent,ostable,sbone, rlocks, plocks)
 	end
 
 	for k,v in pairs(ent.rgmIKChains) do -- calculating IKs twice for proper bone locking stuff to IKs, perhaps there is a simpler way to do these
-		if tobool(tool:GetClientNumber(DefIKnames[v.type],0)) then
+		if tool:GetClientBool(DefIKnames[v.type]) then
 
 			local footdata = ostable[v.foot]
 			if not RTable[footdata.parent] then
@@ -572,7 +572,7 @@ end
 function IsIKBone(tool,ent,bone)
 	if not ent.rgmIKChains then return false end
 	for k,v in pairs(ent.rgmIKChains) do
-		if tobool(tool:GetClientNumber(DefIKnames[v.type],0)) then
+		if tool:GetClientBool(DefIKnames[v.type]) then
 			if bone == v.hip then
 				return true,1
 			elseif bone == v.knee then

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -372,7 +372,7 @@ local function SetBoneOffsets(tool, ent,ostable,sbone, rlocks, plocks)
 	end
 
 	for k,v in pairs(ent.rgmIKChains) do
-		if tool:GetClientBool(DefIKnames[v.type]) then
+		if tool:GetClientNumber(DefIKnames[v.type]) ~= 0 then
 			if v.ikhipparent then
 				if not RTable[v.ikhipparent] then RecursiveSetParent(ostable, sbone, rlocks, plocks, RTable, v.ikhipparent) end
 			end
@@ -388,7 +388,7 @@ local function SetBoneOffsets(tool, ent,ostable,sbone, rlocks, plocks)
 	end
 
 	for k,v in pairs(ent.rgmIKChains) do -- calculating IKs twice for proper bone locking stuff to IKs, perhaps there is a simpler way to do these
-		if tool:GetClientBool(DefIKnames[v.type]) then
+		if tool:GetClientNumber(DefIKnames[v.type]) ~= 0 then
 
 			local footdata = ostable[v.foot]
 			if not RTable[footdata.parent] then
@@ -572,7 +572,7 @@ end
 function IsIKBone(tool,ent,bone)
 	if not ent.rgmIKChains then return false end
 	for k,v in pairs(ent.rgmIKChains) do
-		if tool:GetClientBool(DefIKnames[v.type]) then
+		if tool:GetClientNumber(DefIKnames[v.type]) ~= 0 then
 			if bone == v.hip then
 				return true,1
 			elseif bone == v.knee then

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -571,7 +571,7 @@ function DrawBoneConnections(ent, bone)
 	mainpos = mainpos:ToScreen()
 
 	surface.SetDrawColor( 0, 200, 0, 255 )
-	for _, childbone in ipairs(ent:GetChildBones(bone)) do
+	for _, childbone in ipairs(ent:GetChildBones(bone) or {}) do
 		local pos = ent:GetBonePosition(childbone)
 		pos = pos:ToScreen()
 

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -313,6 +313,7 @@ function GetOffsetTable(tool,ent,rotate, bonelocks)
 end
 
 local function RecursiveSetParent(ostable, sbone, rlocks, plocks, RTable, bone)
+
 	local parent = ostable[bone].parent
 	if not RTable[parent] then RecursiveSetParent(ostable, sbone, rlocks, plocks, RTable, parent) end
 
@@ -357,6 +358,19 @@ local function SetBoneOffsets(tool, ent,ostable,sbone, rlocks, plocks)
 
 			local footdata = ostable[v.foot]
 			if footdata ~= nil and (footdata.parent ~= v.knee and footdata.parent ~= v.hip) and not RTable[footdata.parent] then 
+				RecursiveSetParent(ostable, sbone, rlocks, plocks, RTable, footdata.parent)
+			end
+
+			local RT = ProcessIK(ent,v,sbone,RTable, footdata)
+			table.Merge(RTable,RT)
+		end
+	end
+
+	for k,v in pairs(ent.rgmIKChains) do -- calculating IKs twice for proper bone locking stuff to IKs, perhaps there is a simpler way to do these
+		if tobool(tool:GetClientNumber(DefIKnames[v.type],0)) then
+
+			local footdata = ostable[v.foot]
+			if not RTable[footdata.parent] then
 				RecursiveSetParent(ostable, sbone, rlocks, plocks, RTable, footdata.parent)
 			end
 

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -228,7 +228,13 @@ local DefIKnames = {
 	"ik_leg_L",
 	"ik_leg_R",
 	"ik_hand_L",
-	"ik_hand_R"
+	"ik_hand_R",
+	"ik_chain_1",
+	"ik_chain_2",
+	"ik_chain_3",
+	"ik_chain_4",
+	"ik_chain_5",
+	"ik_chain_6"
 }
 
 --Get bone offsets from parent bones, and update IK data.

--- a/lua/autorun/ragdollmover_meta.lua
+++ b/lua/autorun/ragdollmover_meta.lua
@@ -87,7 +87,7 @@ hook.Add("PlayerSpawn","rgmSpawn",function(pl) --PlayerSpawn is a hook that runs
 		pl.rgmEntLocks = {}
 		pl.rgm.Rotate = false
 		pl.rgm.Scale = false
-		pl.rgm.GizmoOffset = Vector(0, 0, 0)
+		pl.rgm.GizmoOffset = vector_origin
 	end
 
 	if not pl.rgmSync or not pl.rgmSyncOne then

--- a/lua/autorun/ragdollmover_meta.lua
+++ b/lua/autorun/ragdollmover_meta.lua
@@ -83,6 +83,7 @@ hook.Add("PlayerSpawn","rgmSpawn",function(pl) --PlayerSpawn is a hook that runs
 		pl.rgm = {}
 		pl.rgmPosLocks = {}
 		pl.rgmAngLocks = {}
+		pl.rgmBoneLocks = {}
 		pl.rgm.Rotate = false
 		pl.rgm.Scale = false
 		pl.rgm.GizmoOffset = Vector(0, 0, 0)

--- a/lua/autorun/ragdollmover_meta.lua
+++ b/lua/autorun/ragdollmover_meta.lua
@@ -84,6 +84,7 @@ hook.Add("PlayerSpawn","rgmSpawn",function(pl) --PlayerSpawn is a hook that runs
 		pl.rgmPosLocks = {}
 		pl.rgmAngLocks = {}
 		pl.rgmBoneLocks = {}
+		pl.rgmEntLocks = {}
 		pl.rgm.Rotate = false
 		pl.rgm.Scale = false
 		pl.rgm.GizmoOffset = Vector(0, 0, 0)

--- a/lua/entities/rgm_axis/cl_init.lua
+++ b/lua/entities/rgm_axis/cl_init.lua
@@ -1,6 +1,8 @@
 
 include("shared.lua")
 
+local COLOR_RGMGREEN = Color(0,200,0,255)
+
 local TransTable = {
 	"ArrowX", "ArrowY", "ArrowZ",
 	"ArrowXY", "ArrowXZ", "ArrowYZ",
@@ -86,9 +88,9 @@ function ENT:DrawDirectionLine(norm,scale,ghost)
 end
 
 function ENT:DrawAngleText(axis, hitpos, startAngle)
-	local pos = WorldToLocal(hitpos, Angle(0,0,0), axis:GetPos(), axis:GetAngles())
+	local pos = WorldToLocal(hitpos, angle_zero, axis:GetPos(), axis:GetAngles())
 	local overnine
-	pos = WorldToLocal(pos, pos:Angle(), Vector(0, 0, 0), startAngle:Angle())
+	pos = WorldToLocal(pos, pos:Angle(), vector_origin, startAngle:Angle())
 
 	local localized = Vector(pos.x, pos.z, 0):Angle()
 
@@ -100,7 +102,7 @@ function ENT:DrawAngleText(axis, hitpos, startAngle)
 
 	local textAngle = math.abs(math.Round( (overnine - localized.y) * 100 ) / 100)
 	local textpos = hitpos:ToScreen()
-	draw.SimpleText(textAngle,"HudHintTextLarge",textpos.x + 5,textpos.y,Color(0,200,0,255),TEXT_ALIGN_LEFT,TEXT_ALIGN_BOTTOM)
+	draw.SimpleText(textAngle,"HudHintTextLarge",textpos.x + 5,textpos.y,COLOR_RGMGREEN,TEXT_ALIGN_LEFT,TEXT_ALIGN_BOTTOM)
 end
 
 function ENT:Draw()

--- a/lua/entities/rgm_axis/cl_init.lua
+++ b/lua/entities/rgm_axis/cl_init.lua
@@ -4,6 +4,7 @@ include("shared.lua")
 local COLOR_RGMGREEN = Color(0,200,0,255)
 
 local TransTable = {
+	"ArrowOmni",
 	"ArrowX", "ArrowY", "ArrowZ",
 	"ArrowXY", "ArrowXZ", "ArrowYZ",
 	"DiscP", "DiscY", "DiscR", "DiscLarge",
@@ -13,6 +14,7 @@ local TransTable = {
 
 net.Receive("rgmAxis",function(len)
 	local self = net.ReadEntity()
+	self.ArrowOmni =	net.ReadEntity()
 	self.ArrowX =		net.ReadEntity()
 	self.ArrowY =		net.ReadEntity()
 	self.ArrowZ =		net.ReadEntity()
@@ -30,6 +32,7 @@ net.Receive("rgmAxis",function(len)
 	self.ScaleXZ =		net.ReadEntity()
 	self.ScaleYZ =		net.ReadEntity()
 	self.Axises = {
+		self.ArrowOmni,
 		self.ArrowX,
 		self.ArrowY,
 		self.ArrowZ,
@@ -45,7 +48,7 @@ net.Receive("rgmAxis",function(len)
 		self.ScaleZ,
 		self.ScaleXY,
 		self.ScaleXZ,
-		self.ScaleYZ,
+		self.ScaleYZ
 	}
 end)
 
@@ -55,9 +58,9 @@ function ENT:DrawLines(scale,width)
 	local rotate = pl.rgm.Rotate or false
 	local modescale = pl.rgm.Scale or false
 	local collision = self:TestCollision(LocalPlayer(),scale)
-	local Start,End = 1,6
-	if rotate then Start,End = 7,10 end
-	if modescale then Start, End = 11, 16 end
+	local Start,End = 1,7
+	if rotate then Start,End = 8,11 end
+	if modescale then Start, End = 12, 17 end
 	-- print(self.Axises)
 
 	if not self.Axises then

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -22,6 +22,7 @@ local function SendAxisToPlayer(Axis, pl)
 	timer.Simple(0.5, function()
 		net.Start("rgmAxis")
 			net.WriteEntity(Axis)
+			net.WriteEntity(Axis.ArrowOmni)
 			net.WriteEntity(Axis.ArrowX)
 			net.WriteEntity(Axis.ArrowY)
 			net.WriteEntity(Axis.ArrowZ)
@@ -44,6 +45,14 @@ local function SendAxisToPlayer(Axis, pl)
 end
 
 function ENT:Setup()
+
+	self.ArrowOmni = ents.Create("rgm_axis_side_omni")
+		self.ArrowOmni:SetParent(self)
+		self.ArrowOmni:Spawn()
+		self.ArrowOmni:SetColor(Color(255,165,0,255))
+		self.ArrowOmni:SetNWVector("color2",Vector(255,165,0))
+		self.ArrowOmni:SetLocalPos(Vector(0,0,0))
+		self.ArrowOmni:SetLocalAngles(Vector(1,0,0):Angle())
 
 	--Arrows
 	self.ArrowX = ents.Create("rgm_axis_arrow")
@@ -190,6 +199,7 @@ function ENT:Setup()
 		self.ScaleYZ:SetLocalAngles(Vector(1,0,0):Angle())
 
 	self.Axises = {
+		self.ArrowOmni,
 		self.ArrowX,
 		self.ArrowY,
 		self.ArrowZ,
@@ -205,7 +215,7 @@ function ENT:Setup()
 		self.ScaleZ,
 		self.ScaleXY,
 		self.ScaleXZ,
-		self.ScaleYZ,
+		self.ScaleYZ
 	}
 
 	SendAxisToPlayer(self, self.Owner)
@@ -335,6 +345,7 @@ function ENT:Think()
 	local ang = (pos - poseye):Angle()
 	ang = self:WorldToLocalAngles(ang)
 	disc:SetLocalAngles(ang)
+	self.ArrowOmni:SetLocalAngles(ang)
 
 	pos, poseye = self:WorldToLocal(pos), self:WorldToLocal(poseye)
 	local xangle, yangle = (Vector(pos.y, pos.z, 0) - Vector(poseye.y, poseye.z, 0)):Angle(), (Vector(pos.x, pos.z, 0) - Vector(poseye.x, poseye.z, 0)):Angle()

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -10,6 +10,10 @@ local TYPE_ARROW = 1
 local TYPE_ARROWSIDE = 2
 local TYPE_DISC = 3
 
+local VECTOR_FRONT = Vector(1,0,0)
+local ANGLE_DISC = Angle(0,90,0)
+local ANGLE_ARROW_OFFSET = Angle(0,90,90)
+
 util.AddNetworkString("rgmAxisRequest")
 util.AddNetworkString("rgmAxis")
 
@@ -296,7 +300,7 @@ function ENT:Think()
 
 	if not pl.rgm.Moving or not rotate then
 		if offsetlocal then 
-			self:SetPos(LocalToWorld(offset, Angle(0, 0, 0), pos, ang))
+			self:SetPos(LocalToWorld(offset, angle_zero, pos, ang))
 		else
 			self:SetPos(pos + offset)
 		end
@@ -309,18 +313,18 @@ function ENT:Think()
 
 	if not pl.rgm.Moving then -- Prevent whole thing from rotating when we do localized rotation - needed for proper angle reading
 		if localstate or scale or not pl.rgm.IsPhysBone then -- Non phys bones don't go well with world coordinates. Well, I didn't make them to behave with those
-			self:SetAngles(ang or Angle(0,0,0))
+			self:SetAngles(ang or angle_zero)
 			if (ent:GetClass() == "prop_ragdoll" or ent:GetClass() == "prop_dynamic" or ent:GetClass() == "ent_bonemerged") and (not pl.rgm.IsPhysBone) then
 				self.DiscP:SetLocalAngles(Angle(0, 90 + ent:GetManipulateBoneAngles(bone).y, 0)) -- Pitch follows Yaw angles
 				self.DiscR:SetLocalAngles(Angle(0 + ent:GetManipulateBoneAngles(bone).x, 0 + ent:GetManipulateBoneAngles(bone).y, 0)) -- Roll follows Pitch and Yaw angles
 			else
-				self.DiscP:SetLocalAngles(Angle(0, 90, 0))
-				self.DiscR:SetLocalAngles(Angle(0, 0, 0))
+				self.DiscP:SetLocalAngles(ANGLE_DISC)
+				self.DiscR:SetLocalAngles(angle_zero)
 			end
 		else
-			self:SetAngles(Angle(0,0,0))
-			self.DiscP:SetLocalAngles(Angle(0, 90, 0))
-			self.DiscR:SetLocalAngles(Angle(0, 0, 0))
+			self:SetAngles(angle_zero)
+			self.DiscP:SetLocalAngles(ANGLE_DISC)
+			self.DiscR:SetLocalAngles(angle_zero)
 		end
 		self.LocalAngles = ang
 		self.BonePos = pos
@@ -334,7 +338,7 @@ function ENT:Think()
 
 	pos, poseye = self:WorldToLocal(pos), self:WorldToLocal(poseye)
 	local xangle, yangle = (Vector(pos.y, pos.z, 0) - Vector(poseye.y, poseye.z, 0)):Angle(), (Vector(pos.x, pos.z, 0) - Vector(poseye.x, poseye.z, 0)):Angle()
-	local XAng, YAng, ZAng = Angle(0, 0, xangle.y + 90) + Vector(1,0,0):Angle(), Angle(0, 90, 90) - Angle(0,0,yangle.y), Angle(0, ang.y, 0) + Vector(0,0,1):Angle()
+	local XAng, YAng, ZAng = Angle(0, 0, xangle.y + 90) + VECTOR_FRONT:Angle(), ANGLE_ARROW_OFFSET - Angle(0,0,yangle.y), Angle(0, ang.y, 0) + vector_up:Angle()
 	self.ArrowX:SetLocalAngles(XAng)
 	self.ScaleX:SetLocalAngles(XAng)
 	self.ArrowY:SetLocalAngles(YAng)

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -3,6 +3,7 @@ ENT.Type = "anim"
 ENT.Base = "base_entity"
 
 local TransTable = {
+	"ArrowOmni",
 	"ArrowX", "ArrowY", "ArrowZ",
 	"ArrowXY", "ArrowXZ", "ArrowYZ",
 	"DiscP", "DiscY", "DiscR", "DiscLarge",
@@ -24,9 +25,9 @@ function ENT:TestCollision(pl,scale)
 	-- PrintTable(self:GetTable())
 	local rotate = pl.rgm.Rotate or false
 	local modescale = pl.rgm.Scale or false
-	local Start,End = 1,6
-	if rotate then Start,End = 7,10 end
-	if modescale then Start, End = 11, 16 end
+	local Start,End = 1,7
+	if rotate then Start,End = 8,11 end
+	if modescale then Start, End = 12, 17 end
 
 	local cols = {}
 	if not self.Axises then return false end

--- a/lua/entities/rgm_axis_arrow/cl_init.lua
+++ b/lua/entities/rgm_axis_arrow/cl_init.lua
@@ -5,7 +5,7 @@ local VECTOR_FRONT = Vector(1,0,0)
 
 function ENT:GetLinePositions(width)
 	local RTable = {}
-	RTable[1] = {Vector(0.075*width,-0.075*width,0),Vector(0.75,-0.075*width,0),Vector(0.75,0.075*width,0),Vector(0.075*width,0.075*width,0)}
+	RTable[1] = {Vector(0.1,-0.075*width,0),Vector(0.75,-0.075*width,0),Vector(0.75,0.075*width,0),Vector(0.1,0.075*width,0)}
 	RTable[2] = {Vector(0.75,-0.0625 - 0.0625*width,0), VECTOR_FRONT,VECTOR_FRONT,Vector(0.75,0.0625 + 0.0625*width,0)}
 	return RTable
 end

--- a/lua/entities/rgm_axis_arrow/cl_init.lua
+++ b/lua/entities/rgm_axis_arrow/cl_init.lua
@@ -1,9 +1,11 @@
 
 include("shared.lua")
 
+local VECTOR_FRONT = Vector(1,0,0)
+
 function ENT:GetLinePositions(width)
 	local RTable = {}
 	RTable[1] = {Vector(0.075*width,-0.075*width,0),Vector(0.75,-0.075*width,0),Vector(0.75,0.075*width,0),Vector(0.075*width,0.075*width,0)}
-	RTable[2] = {Vector(0.75,-0.0625 - 0.0625*width,0), Vector(1,0,0),Vector(1,0,0),Vector(0.75,0.0625 + 0.0625*width,0)}
+	RTable[2] = {Vector(0.75,-0.0625 - 0.0625*width,0), VECTOR_FRONT,VECTOR_FRONT,Vector(0.75,0.0625 + 0.0625*width,0)}
 	return RTable
 end

--- a/lua/entities/rgm_axis_arrow/init.lua
+++ b/lua/entities/rgm_axis_arrow/init.lua
@@ -9,7 +9,7 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 	local axis = self:GetParent()
 	local offset = axis.Owner.rgm.GizmoOffset
 	if axis.localizedoffset then
-		offset = LocalToWorld(offset, Angle(0, 0, 0), axis:GetPos(), axis.LocalAngles)
+		offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
 		offset =  offset - axis:GetPos()
 	end
 	local pos, ang
@@ -19,7 +19,7 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		localized = Vector(localized.x,0,0)
 		intersect = self:LocalToWorld(localized)
 		ang = obj:GetAngles()
-		pos = LocalToWorld(Vector(offpos.x,0,0),Angle(0,0,0),intersect - offset,self:GetAngles())
+		pos = LocalToWorld(Vector(offpos.x,0,0),angle_zero,intersect - offset,self:GetAngles())
 	elseif movetype == 2 then
 		pos = ent:GetManipulateBonePosition(bone)
 		localized = Vector(localized.x - StartGrab.x,0,0)
@@ -30,7 +30,7 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		localized = Vector(localized.x,0,0)
 		intersect = self:LocalToWorld(localized)
 		ang = ent:GetLocalAngles()
-		pos = LocalToWorld(Vector(offpos.x,0,0),Angle(0,0,0),intersect - offset, self:GetAngles())
+		pos = LocalToWorld(Vector(offpos.x,0,0),angle_zero,intersect - offset, self:GetAngles())
 		pos = ent:GetParent():WorldToLocal(pos)
 	end
 	return pos,ang

--- a/lua/entities/rgm_axis_arrow/init.lua
+++ b/lua/entities/rgm_axis_arrow/init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, StartGrab, NPhysPos)
+function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, garbage, StartGrab, NPhysPos)
 	local intersect = self:GetGrabPos(eyepos,eyeang,ppos)
 	local localized = self:WorldToLocal(intersect)
 	local axis = self:GetParent()

--- a/lua/entities/rgm_axis_arrow/shared.lua
+++ b/lua/entities/rgm_axis_arrow/shared.lua
@@ -20,7 +20,7 @@ function ENT:TestCollision(pl,scale)
 	local eyepos,eyeang = rgm.EyePosAng(pl)
 	local intersect = self:GetGrabPos(eyepos,eyeang)
 	local localized = self:WorldToLocal(intersect)
-	local distmin = Vector(0,-0.075*scale,-0.075*scale)
+	local distmin = Vector(0.1*scale,-0.075*scale,-0.075*scale)
 	local distmax = Vector(1*scale,0.075*scale,0.075*scale)
 	if localized.x >= distmin.x and localized.x <= distmax.x
 	and localized.y >= distmin.y and localized.y <= distmax.y

--- a/lua/entities/rgm_axis_disc/cl_init.lua
+++ b/lua/entities/rgm_axis_disc/cl_init.lua
@@ -1,9 +1,12 @@
 
 include("shared.lua")
 
+local VECTOR_RED = Vector(255,0,0)
+local ANG = Angle(0,0,11.25)
+
 function ENT:GetLinePositions(width)
 	local RTable = {}
-	local ang = Angle(0,0,11.25)
+	local ang = ANG
 	local startposmin = Vector(0,0,1 - 0.1*width)
 	local startposmax = Vector(0,0,1 + 0.1*width)
 	for i=1,32 do
@@ -20,6 +23,8 @@ function ENT:GetLinePositions(width)
 	return RTable
 end
 
+local COLOR_YELLOW = Color(255,255,0,255)
+
 function ENT:DrawLines(yellow,scale,width)
 	local ToScreen = {}
 	local linetable = self:GetLinePositions(width)
@@ -30,7 +35,7 @@ function ENT:DrawLines(yellow,scale,width)
 	local borderpos = largedisc:GetPos()
 	local color = self:GetColor()
 	color = Color(color.r,color.g,color.b,color.a)
-	local color2 = self:GetNWVector("color2",Vector(255,0,0))
+	local color2 = self:GetNWVector("color2",VECTOR_RED)
 	color2 = Color(color2.x,color2.y,color2.z,255)
 	local moving = LocalPlayer().rgm.Moving or false
 
@@ -38,7 +43,7 @@ function ENT:DrawLines(yellow,scale,width)
 		local points = self:PointsToWorld(v, scale)
 		local col = color
 		if yellow then
-			col = Color(255,255,0,255)
+			col = COLOR_YELLOW
 		end
 		if GetConVar("ragdollmover_fulldisc"):GetBool() or (moving or
 		(points[1]:DistToSqr(eyepos) <= borderpos:DistToSqr(eyepos) and points[2]:DistToSqr(eyepos) <= borderpos:DistToSqr(eyepos) and 

--- a/lua/entities/rgm_axis_disc/init.lua
+++ b/lua/entities/rgm_axis_disc/init.lua
@@ -3,6 +3,8 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
+local VECTOR_FRONT, VECTOR_SIDE = Vector(1,0,0), Vector(0,1,0)
+
 local function ConvertVector(vec, axistype)
 	local rotationtable, result
 
@@ -25,9 +27,9 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 	local _p, _a
 	local pl = self:GetParent().Owner
 	local axistable = {
-		(self:GetParent():LocalToWorld(Vector(0,1,0)) - self:GetPos()):Angle(),
-		(self:GetParent():LocalToWorld(Vector(0,0,1)) - self:GetPos()):Angle(),
-		(self:GetParent():LocalToWorld(Vector(1,0,0)) - self:GetPos()):Angle(),
+		(self:GetParent():LocalToWorld(VECTOR_SIDE) - self:GetPos()):Angle(),
+		(self:GetParent():LocalToWorld(vector_up) - self:GetPos()):Angle(),
+		(self:GetParent():LocalToWorld(VECTOR_FRONT) - self:GetPos()):Angle(),
 		(self:GetPos()-pl:EyePos()):Angle()
 	}
 
@@ -36,7 +38,7 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		local axis = self:GetParent()
 		local offset = axis.Owner.rgm.GizmoOffset
 		if axis.localizedoffset and not axis.relativerotate then
-			offset = LocalToWorld(offset, Angle(0,0,0), axis:GetPos(), axis.LocalAngles)
+			offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
 			offset = offset - axis:GetPos()
 		end
 
@@ -44,11 +46,11 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		local pos = self:GetPos()
 		local ang = self:LocalToWorldAngles(Angle(0,0,localized.y))
 		if axis.relativerotate then
-			offset = WorldToLocal(axis.BonePos, Angle(0, 0, 0), axis:GetPos(), axis.LocalAngles)
-			_p,_a = LocalToWorld(Vector(0,0,0),offang,pos,ang)
+			offset = WorldToLocal(axis.BonePos, angle_zero, axis:GetPos(), axis.LocalAngles)
+			_p,_a = LocalToWorld(vector_origin,offang,pos,ang)
 			_p = LocalToWorld(offset, _a, pos, _a)
 		else
-			_p,_a = LocalToWorld(Vector(0,0,0),offang,pos,ang)
+			_p,_a = LocalToWorld(vector_origin,offang,pos,ang)
 			_p = pos - offset
 		end
 	elseif movetype == 2 then
@@ -56,10 +58,10 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		axisangle = axistable[self.axistype]
 
 		local _, boneang = ent:GetBonePosition(bone)
-		local startlocal = LocalToWorld(startAngle, startAngle:Angle(), Vector(0,0,0), axisangle) -- first we get our vectors into world coordinates, relative to the axis angles
-		localized = LocalToWorld(localized, localized:Angle(), Vector(0,0,0), axisangle)
-		localized = WorldToLocal(localized, localized:Angle(), Vector(0,0,0), boneang) -- then convert that vector to the angles of the bone
-		startlocal = WorldToLocal(startlocal, startlocal:Angle(), Vector(0,0,0), boneang)
+		local startlocal = LocalToWorld(startAngle, startAngle:Angle(), vector_origin, axisangle) -- first we get our vectors into world coordinates, relative to the axis angles
+		localized = LocalToWorld(localized, localized:Angle(), vector_origin, axisangle)
+		localized = WorldToLocal(localized, localized:Angle(), vector_origin, boneang) -- then convert that vector to the angles of the bone
+		startlocal = WorldToLocal(startlocal, startlocal:Angle(), vector_origin, boneang)
 
 		localized = ConvertVector(localized, self.axistype)
 		startlocal = ConvertVector(startlocal, self.axistype)
@@ -80,7 +82,7 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		local axis = self:GetParent()
 		local offset = axis.Owner.rgm.GizmoOffset
 		if axis.localizedoffset and not axis.relativerotate then
-			offset = LocalToWorld(offset, Angle(0,0,0), axis:GetPos(), axis.LocalAngles)
+			offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
 			offset = offset - axis:GetPos()
 		end
 
@@ -88,13 +90,13 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		local pos = self:GetPos()
 		local ang = self:LocalToWorldAngles(Angle(0,0,localized.y))
 		if axis.relativerotate then
-			offset = WorldToLocal(axis.BonePos, Angle(0, 0, 0), axis:GetPos(), axis.LocalAngles)
-			_p,_a = LocalToWorld(Vector(0,0,0),offang,pos,ang)
+			offset = WorldToLocal(axis.BonePos, angle_zero, axis:GetPos(), axis.LocalAngles)
+			_p,_a = LocalToWorld(vector_origin,offang,pos,ang)
 			_p = LocalToWorld(offset, _a, pos, _a)
 			_a = ent:GetParent():WorldToLocalAngles(_a)
 			_p = ent:GetParent():WorldToLocal(_p)
 		else
-			_p,_a = LocalToWorld(Vector(0,0,0),offang,pos,ang)
+			_p,_a = LocalToWorld(vector_origin,offang,pos,ang)
 			_p = pos - offset
 			_a = ent:GetParent():WorldToLocalAngles(_a)
 			_p = ent:GetParent():WorldToLocal(_p)

--- a/lua/entities/rgm_axis_disc/init.lua
+++ b/lua/entities/rgm_axis_disc/init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-local VECTOR_FRONT, VECTOR_SIDE = Vector(1,0,0), Vector(0,1,0) 
+local VECTOR_FRONT, VECTOR_SIDE = Vector(1,0,0), Vector(0,1,0)
 
 local function ConvertVector(vec, axistype)
 	local rotationtable, result

--- a/lua/entities/rgm_axis_disc_large/cl_init.lua
+++ b/lua/entities/rgm_axis_disc_large/cl_init.lua
@@ -1,19 +1,23 @@
 
 include("shared.lua")
 
+local VECTOR_RED = Vector(255,0,0)
+
+local COLOR_YELLOW = Color(255,255,0,255)
+
 function ENT:DrawLines(yellow,scale,width)
 	-- self.BaseClass.DrawLines(self,yellow,scale*1.25)
 	local ToScreen = {}
 	local linetable = self:GetLinePositions(width)
 	local color = self:GetColor()
 	color = Color(color.r,color.g,color.b,color.a)
-	local color2 = self:GetNWVector("color2",Vector(255,0,0))
+	local color2 = self:GetNWVector("color2",VECTOR_RED)
 	color2 = Color(color2.x,color2.y,color2.z,255)
 	local moving = LocalPlayer():GetNWBool("ragdollmover_moving",false)
 	for i,v in ipairs(linetable) do
 		local col = color
 		if yellow then
-			col = Color(255,255,0,255)
+			col = COLOR_YELLOW
 		end
 		local points = self:PointsToWorld(v, scale*1.25)
 		table.insert(ToScreen,{points,col})

--- a/lua/entities/rgm_axis_part/cl_init.lua
+++ b/lua/entities/rgm_axis_part/cl_init.lua
@@ -1,6 +1,8 @@
 
 include("shared.lua")
 
+local VECTOR_RED = Vector(255,0,0)
+
 --To be overwritten
 function ENT:GetLinePositions()
 end
@@ -13,19 +15,21 @@ function ENT:PointsToWorld(vectors, scale)
 	return translated
 end
 
+local COLOR_YELLOW = Color(255,255,0,255)
+
 function ENT:DrawLines(yellow,scale,width)
 	local ToScreen = {}
 	local linetable = self:GetLinePositions(width)
 	local color = self:GetColor()
 	color = Color(color.r,color.g,color.b,color.a)
-	local color2 = self:GetNWVector("color2",Vector(255,0,0))
+	local color2 = self:GetNWVector("color2",VECTOR_RED)
 	color2 = Color(color2.x,color2.y,color2.z,255)
 
 	for i,v in ipairs(linetable) do
 		local points = self:PointsToWorld(v, scale)
 		local col = color
 		if yellow then
-			col = Color(255,255,0,255)
+			col = COLOR_YELLOW
 		end
 		table.insert(ToScreen,{points,col})
 	end

--- a/lua/entities/rgm_axis_scale_arrow/init.lua
+++ b/lua/entities/rgm_axis_scale_arrow/init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, StartGrab, garbage, garbage, NPhysScale)
+function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, garbage, StartGrab, garbage, garbage, NPhysScale)
 	local intersect = self:GetGrabPos(eyepos,eyeang,ppos)
 	local localized = self:WorldToLocal(intersect)
 	local pos, ang

--- a/lua/entities/rgm_axis_scale_side/init.lua
+++ b/lua/entities/rgm_axis_scale_side/init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, startGrab, garbage, garbage, NPhysScale)
+function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, garbage, startGrab, garbage, garbage, NPhysScale)
 	local intersect = self:GetGrabPos(eyepos,eyeang,ppos,pnorm)
 	local pos, ang
 	local pl = self:GetParent().Owner

--- a/lua/entities/rgm_axis_scale_side/init.lua
+++ b/lua/entities/rgm_axis_scale_side/init.lua
@@ -16,12 +16,12 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		if IsValid(ent) then
 			boneang = ent:GetAngles()
 		else
-			boneang = Angle(0,0,0)
+			boneang = angle_zero
 		end
 	end
 
-	localized = LocalToWorld(offpos,Angle(0,0,0),intersect,self:GetAngles())
-	localized = WorldToLocal(localized, Angle(0,0,0), self:GetPos(), boneang)
+	localized = LocalToWorld(offpos,angle_zero,intersect,self:GetAngles())
+	localized = WorldToLocal(localized, angle_zero, self:GetPos(), boneang)
 
 	finalpos = NPhysScale + localized
 	ang = ent:GetManipulateBoneAngles(bone)

--- a/lua/entities/rgm_axis_side/cl_init.lua
+++ b/lua/entities/rgm_axis_side/cl_init.lua
@@ -1,6 +1,8 @@
 
 include("shared.lua")
 
+local VECTOR_RED = Vector(255,0,0)
+
 function ENT:GetLinePositions(width)
 	local RTable = {}
 	RTable[1] = {Vector(0,0.25 - 0.05*width,0),Vector(0,0.25 - 0.05*width,0.25 - 0.05*width),Vector(0,0.25 + 0.05*width,0.25 + 0.05*width),Vector(0,0.25 + 0.05*width,0)}
@@ -8,18 +10,20 @@ function ENT:GetLinePositions(width)
 	return RTable
 end
 
+local COLOR_YELLOW = Color(255,255,0,255)
+
 function ENT:DrawLines(yellow,scale,width)
 	local ToScreen = {}
 	local linetable = self:GetLinePositions(width)
 	local color = self:GetColor()
 	color = Color(color.r,color.g,color.b,color.a)
-	local color2 = self:GetNWVector("color2",Vector(255,0,0))
+	local color2 = self:GetNWVector("color2",VECTOR_RED)
 	color2 = Color(color2.x,color2.y,color2.z,255)
 	for i,v in ipairs(linetable) do
 		local points = self:PointsToWorld(v, scale)
 		local col = color
 		if yellow then
-			col = Color(255,255,0,255)
+			col = COLOR_YELLOW
 		elseif i == 2 then
 			col = color2
 		end

--- a/lua/entities/rgm_axis_side/init.lua
+++ b/lua/entities/rgm_axis_side/init.lua
@@ -8,7 +8,7 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 	local axis = self:GetParent()
 	local offset = axis.Owner.rgm.GizmoOffset
 	if axis.localizedoffset then
-		offset = LocalToWorld(offset, Angle(0, 0, 0), axis:GetPos(), axis.LocalAngles)
+		offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
 		offset =  offset - axis:GetPos()
 	end
 	local pos, ang
@@ -17,7 +17,7 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 	if movetype == 1 then
 		local obj = ent:GetPhysicsObjectNum(bone)
 		ang = obj:GetAngles()
-		pos = LocalToWorld(offpos,Angle(0,0,0),intersect - offset,self:GetAngles())
+		pos = LocalToWorld(offpos,angle_zero,intersect - offset,self:GetAngles())
 	elseif movetype == 2 then
 		local localized, startmove, finalpos, boneang
 		if ent:GetBoneParent(bone) ~= -1 then
@@ -27,19 +27,19 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 			if IsValid(ent) then
 				boneang = ent:GetAngles()
 			else
-				boneang = Angle(0,0,0)
+				boneang = angle_zero
 			end
 		end
 
-		localized = LocalToWorld(offpos,Angle(0,0,0),intersect,self:GetAngles())
-		localized = WorldToLocal(localized, Angle(0,0,0), self:GetPos(), boneang)
+		localized = LocalToWorld(offpos,angle_zero,intersect,self:GetAngles())
+		localized = WorldToLocal(localized, angle_zero, self:GetPos(), boneang)
 
 		finalpos = NPhysPos + localized
 		ang = ent:GetManipulateBoneAngles(bone)
 		pos = finalpos
 	elseif movetype == 0 then
 		ang = ent:GetLocalAngles()
-		pos = LocalToWorld(offpos,Angle(0,0,0),intersect - offset,self:GetAngles())
+		pos = LocalToWorld(offpos,angle_zero,intersect - offset,self:GetAngles())
 		pos = ent:GetParent():WorldToLocal(pos)
 	end
 

--- a/lua/entities/rgm_axis_side/init.lua
+++ b/lua/entities/rgm_axis_side/init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, startGrab, NPhysPos)
+function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, movetype, garbage, startGrab, NPhysPos)
 	local intersect = self:GetGrabPos(eyepos,eyeang,ppos,pnorm)
 	local axis = self:GetParent()
 	local offset = axis.Owner.rgm.GizmoOffset

--- a/lua/entities/rgm_axis_side_omni/cl_init.lua
+++ b/lua/entities/rgm_axis_side_omni/cl_init.lua
@@ -1,0 +1,8 @@
+
+include("shared.lua")
+
+function ENT:GetLinePositions(width)
+	local RTable = {}
+	RTable[1] = {Vector(0,-0.08*width,-0.08*width),Vector(0,-0.08*width,0.08*width),Vector(0,0.08*width,0.08*width),Vector(0,0.08*width,-0.08*width)}
+	return RTable
+end

--- a/lua/entities/rgm_axis_side_omni/init.lua
+++ b/lua/entities/rgm_axis_side_omni/init.lua
@@ -1,0 +1,51 @@
+
+include("shared.lua")
+AddCSLuaFile("cl_init.lua")
+AddCSLuaFile("shared.lua")
+
+function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm,movetype,_,startGrab,NPhysPos,_,_,tracepos)
+	local intersect = tracepos
+	if not intersect then
+		intersect = self:GetGrabPos(eyepos,eyeang,ppos,pnorm)
+	end
+
+	local axis = self:GetParent()
+	local offset = axis.Owner.rgm.GizmoOffset
+	if axis.localizedoffset then
+		offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
+		offset =  offset - axis:GetPos()
+	end
+	local pos, ang
+	local pl = self:GetParent().Owner
+
+	if movetype == 1 then
+		local obj = ent:GetPhysicsObjectNum(bone)
+		ang = obj:GetAngles()
+		pos = LocalToWorld(offpos,angle_zero,intersect - offset,self:GetAngles())
+	elseif movetype == 2 then
+		local localized, startmove, finalpos, boneang
+		if ent:GetBoneParent(bone) ~= -1 then
+			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
+			boneang = matrix:GetAngles()
+		else
+			if IsValid(ent) then
+				boneang = ent:GetAngles()
+			else
+				boneang = angle_zero
+			end
+		end
+
+		localized = LocalToWorld(offpos,angle_zero,intersect,self:GetAngles())
+		localized = WorldToLocal(localized, angle_zero, self:GetPos(), boneang)
+
+		finalpos = NPhysPos + localized
+		ang = ent:GetManipulateBoneAngles(bone)
+		pos = finalpos
+	elseif movetype == 0 then
+		ang = ent:GetLocalAngles()
+		pos = LocalToWorld(offpos,angle_zero,intersect - offset,self:GetAngles())
+		pos = ent:GetParent():WorldToLocal(pos)
+	end
+
+	return pos,ang
+end

--- a/lua/entities/rgm_axis_side_omni/shared.lua
+++ b/lua/entities/rgm_axis_side_omni/shared.lua
@@ -1,0 +1,18 @@
+
+ENT.Type = "anim"
+ENT.Base = "rgm_axis_side"
+
+function ENT:TestCollision(pl,scale)
+	local Type = self:GetNWInt("type",1)
+	local eyepos,eyeang = rgm.EyePosAng(pl)
+	local intersect = self:GetGrabPos(eyepos,eyeang)
+	local localized = self:WorldToLocal(intersect)
+	local distmin1 = Vector(-0.075*scale, scale*(-0.08), scale*(-0.08))
+	local distmax1 = Vector(0.075*scale, scale*0.08, scale*0.08)
+	if (localized.x >= distmin1.x and localized.x <= distmax1.x
+	and localized.y >= distmin1.y and localized.y <= distmax1.y
+	and localized.z >= distmin1.z and localized.z <= distmax1.z) then
+		return {axis = self,hitpos = intersect}
+	end
+	return false
+end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1916,7 +1916,7 @@ local function RGMBuildEntMenu(parent, children, entpanel)
 
 	MakeChildrenList(parent, sortchildren)
 
-	entpanel:UpdateWidth(width + 8 + 32)
+	entpanel:UpdateWidth(width + 8 + 32 + 16)
 end
 
 local function RGMBuildConstrainedEnts(parent, children, entpanel)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -192,7 +192,7 @@ net.Receive("rgmLockBone", function(len, pl)
 
 	if not IsValid(ent) or ent:TranslateBoneToPhysBone(bone) == -1 then return end
 	if ent:GetClass() ~= "prop_ragdoll" then return end
-	bone = BoneToPhysBone(ent,bone)
+	bone = rgm.BoneToPhysBone(ent,bone)
 
 	if mode == 1 then
 		if not pl.rgmPosLocks[bone] then

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -749,7 +749,7 @@ function TOOL:LeftClick(tr)
 		local entity
 		entity = tr.Entity
 
-		if entity ~= pl.rgm.Entity and self:GetClientBool("lockselected") then
+		if entity ~= pl.rgm.Entity and self:GetClientNumber("lockselected") ~= 0 then
 			net.Start("rgmNotification")
 				net.WriteUInt(RGM_NOTIFY.ENTSELECT_LOCKRESPONSE.id, 5)
 			net.Send(pl)
@@ -912,20 +912,20 @@ if SERVER then
 
 	local axis = pl.rgm.Axis
 	if IsValid(axis) then
-		if axis.localizedpos ~= self:GetClientBool("localpos",true) then
-			axis.localizedpos = self:GetClientBool("localpos",true)
+		if axis.localizedpos ~= (self:GetClientNumber("localpos",1) ~= 0) then
+			axis.localizedpos = (self:GetClientNumber("localpos",1) ~= 0)
 		end
-		if axis.localizedang ~= self:GetClientBool("localang",true) then
-			axis.localizedang = self:GetClientBool("localang",true)
+		if axis.localizedang ~= (self:GetClientNumber("localang",1) ~= 0) then
+			axis.localizedang = (self:GetClientNumber("localang",1) ~= 0)
 		end
-		if axis.localizedoffset ~= self:GetClientBool("localoffset",true) then
-			axis.localizedoffset = self:GetClientBool("localoffset",true)
+		if axis.localizedoffset ~= (self:GetClientNumber("localoffset",1) ~= 0) then
+			axis.localizedoffset = (self:GetClientNumber("localoffset",1) ~= 0)
 		end
-		if axis.relativerotate ~= self:GetClientBool("relativerotate",true) then
-			axis.relativerotate = self:GetClientBool("relativerotate",true)
+		if axis.relativerotate ~= (self:GetClientNumber("relativerotate",1) ~= 0) then
+			axis.relativerotate = (self:GetClientNumber("relativerotate",1) ~= 0)
 		end
-		if axis.scalechildren ~= self:GetClientBool("scalechildren",true) then
-			axis.scalechildren = self:GetClientBool("scalechildren",true)
+		if axis.scalechildren ~= (self:GetClientNumber("scalechildren",1) ~= 0) then
+			axis.scalechildren = (self:GetClientNumber("scalechildren",1) ~= 0)
 		end
 	end
 
@@ -1143,7 +1143,8 @@ local function GetRecursiveBonesExclusive(ent, boneid, lastvalidbone, tab, physc
 
 		if ent:BoneHasFlag(v, 4) then -- BONE_ALWAYS_PROCEDURAL flag
 			bone.Type = BONE_PROCEDURAL
-		elseif physcheck[v] then
+		end
+		if physcheck[v] then
 			bone.Type = BONE_PHYSICAL
 		end
 
@@ -1822,7 +1823,8 @@ local function UpdateBoneNodes(ent, bonepanel, physIDs, isphys)
 			local bone = { id = v, Type = BONE_NONPHYSICAL, depth = 1 }
 			if ent:BoneHasFlag(v, 4) then
 				bone.Type = BONE_PROCEDURAL
-			elseif physIDs[v] then
+			end
+			if physIDs[v] then
 				bone.Type = BONE_PHYSICAL
 			end
 
@@ -2426,7 +2428,7 @@ function TOOL:DrawHUD()
 
 	local tr = pl:GetEyeTrace()
 	local aimedbone = IsValid(tr.Entity) and (tr.Entity:GetClass() == "prop_ragdoll" and pl.rgm.AimedBone or 0) or 0
-	if IsValid(ent) and EntityFilter(ent) and self:GetClientBool("drawskeleton") then
+	if IsValid(ent) and EntityFilter(ent) and self:GetClientNumber("drawskeleton") ~= 0 then
 		rgm.DrawSkeleton(ent)
 	end
 

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -22,6 +22,12 @@ TOOL.ClientConVar["ik_leg_L"] = 0
 TOOL.ClientConVar["ik_leg_R"] = 0
 TOOL.ClientConVar["ik_hand_L"] = 0
 TOOL.ClientConVar["ik_hand_R"] = 0
+TOOL.ClientConVar["ik_chain_1"] = 0
+TOOL.ClientConVar["ik_chain_2"] = 0
+TOOL.ClientConVar["ik_chain_3"] = 0
+TOOL.ClientConVar["ik_chain_4"] = 0
+TOOL.ClientConVar["ik_chain_5"] = 0
+TOOL.ClientConVar["ik_chain_6"] = 0
 TOOL.ClientConVar["hipkneeroll"] = 3
 TOOL.ClientConVar["ignoredaxis"] = 3
 
@@ -1265,19 +1271,16 @@ local function CCol(cpanel,text, notexpanded)
 end
 local function CBinder(cpanel)
 	local parent = vgui.Create("Panel", cpanel)
-	parent:SetHeight(80)
 	cpanel:AddItem(parent)
 
 	local bindrot = vgui.Create("DBinder", parent)
 	bindrot.Label = vgui.Create("DLabel", parent)
 	bindrot:SetConVar("ragdollmover_rotatebutton")
 	bindrot:SetSize(100, 50)
-	bindrot:SetPos(25, 25)
 
 	bindrot.Label:SetText("#tool.ragdollmover.bindrot")
 	bindrot.Label:SetDark(true)
 	bindrot.Label:SizeToContents()
-	bindrot.Label:SetPos(25, 0)
 
 	function bindrot:OnChange(keycode)
 		net.Start("rgmSetToggleRot")
@@ -1289,18 +1292,65 @@ local function CBinder(cpanel)
 	bindsc.Label = vgui.Create("DLabel", parent)
 	bindsc:SetConVar("ragdollmover_scalebutton")
 	bindsc:SetSize(100, 50)
-	bindsc:SetPos(135, 25)
 
 	bindsc.Label:SetText("#tool.ragdollmover.bindscale")
 	bindsc.Label:SetDark(true)
 	bindsc.Label:SizeToContents()
-	bindsc.Label:SetPos(137, 0)
 
 	function bindsc:OnChange(keycode)
 		net.Start("rgmSetToggleScale")
 		net.WriteInt(keycode, 32)
 		net.SendToServer()
 	end
+
+	local rotw, scw = bindrot.Label:GetWide(), bindsc.Label:GetWide()
+
+	parent.PerformLayout = function()
+		parent:SetHeight(80)
+
+		bindrot:SetPos(parent:GetWide()/2 - 100 - 5 - 30 *(parent:GetWide()/217 - 1), 25)
+		bindrot.Label:SetPos(bindrot:GetX() + 50 - rotw/2, 0)
+		bindrot.Label:SetWidth(parent:GetWide()/2 - bindrot.Label:GetX())
+
+		bindsc:SetPos(parent:GetWide()/2 + 5 + 30 *(parent:GetWide()/217 - 1), 25)
+		bindsc.Label:SetPos(bindsc:GetX() + 50 - scw/2, 0)
+		bindsc.Label:SetWidth(parent:GetWide() - bindsc.Label:GetX())
+	end
+end
+
+local AdditionalIKs = {
+	"ragdollmover_ik_chain_1",
+	"ragdollmover_ik_chain_2",
+	"ragdollmover_ik_chain_3",
+	"ragdollmover_ik_chain_4",
+	"ragdollmover_ik_chain_5",
+	"ragdollmover_ik_chain_6"
+}
+
+local function CBAdditionalIKs(cpanel, text)
+	local butt = vgui.Create("DButton", cpanel)
+	butt:SetText(text)
+	function butt:DoClick()
+		local menu = DermaMenu(false, cpanel)
+		local panel = vgui.Create("Panel")
+		panel:SetSize(100, 125)
+		panel.iks = {}
+
+		for i = 1, 6 do
+			panel.iks[i] = vgui.Create("DCheckBoxLabel", panel)
+			panel.iks[i]:SetText(language.GetPhrase("tool.ragdollmover.ikchain") .. " " ..i)
+			panel.iks[i]:SetDark(true)
+			panel.iks[i]:SetConVar(AdditionalIKs[i])
+			panel.iks[i]:SetSize(90, 15)
+			panel.iks[i]:SetPos(5, 5 + 20*(i - 1))
+		end
+
+		menu:AddPanel(panel)
+		menu:Open()
+	end
+	cpanel:AddItem(butt)
+
+	return butt
 end
 
 local function RGMResetGizmo()
@@ -2086,6 +2136,7 @@ function TOOL.BuildCPanel(CPanel)
 		CCheckBox(Col2,"#tool.ragdollmover.ik1","ragdollmover_ik_leg_L")
 		CCheckBox(Col2,"#tool.ragdollmover.ik2","ragdollmover_ik_leg_R")
 		CButton(Col2, "#tool.ragdollmover.ikall", RGMSelectAllIK)
+		CBAdditionalIKs(Col2, "#tool.ragdollmover.additional")
 
 	local Col3 = CCol(CPanel,"#tool.ragdollmover.miscpanel")
 		CCheckBox(Col3, "#tool.ragdollmover.lockselected","ragdollmover_lockselected")

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -227,7 +227,7 @@ net.Receive("rgmSelectBone", function(len, pl)
 	local ent = net.ReadEntity()
 	local bone = net.ReadUInt(32)
 
-	pl.rgm.BoneToResetTo = 0
+	pl.rgm.BoneToResetTo = (ent:GetClass() == "prop_ragdoll") and ent:TranslatePhysBoneToBone(0) or 0
 	RGMGetBone(pl, ent, bone)
 	pl:rgmSync()
 
@@ -394,7 +394,7 @@ net.Receive("rgmSelectEntity", function(len, pl)
 	if not IsValid(ent) then return end
 
 	pl.rgm.Entity = ent
-	pl.rgm.BoneToResetTo = 0
+	pl.rgm.BoneToResetTo = (ent:GetClass() == "prop_ragdoll") and ent:TranslatePhysBoneToBone(0) or 0
 	pl.rgmPosLocks = {}
 	pl.rgmAngLocks = {}
 	pl.rgmBoneLocks = {}
@@ -768,7 +768,7 @@ function TOOL:LeftClick(tr)
 		end
 
 		RGMGetBone(pl, entity, entity:TranslatePhysBoneToBone(tr.PhysicsBone))
-		pl.rgm.BoneToResetTo = 0 -- used for quickswitching to root bone and back
+		pl.rgm.BoneToResetTo = (entity:GetClass() == "prop_ragdoll") and entity:TranslatePhysBoneToBone(0) or 0 -- used for quickswitching to root bone and back
 
 		if ent ~= pl.rgm.ParentEntity then
 			local children = rgmFindEntityChildren(pl.rgm.ParentEntity)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1542,7 +1542,7 @@ local function SetBoneNodes(bonepanel, ent, sortedbones)
 					net.SendToServer()
 
 					conentnodes[LockTo]:SetIcon("icon16/brick_link.png")
-					conentnodes[LockTo]:SetToolTip(false)
+					conentnodes[LockTo].Label:SetToolTip(false)
 				end
 
 				LockMode = false
@@ -1697,6 +1697,12 @@ local function SetBoneNodes(bonepanel, ent, sortedbones)
 				option = bonemenu:AddOption("#tool.ragdollmover.lockbone", function()
 					if not pl.rgm then return end
 					if not IsValid(pl.rgm.Entity) then return end
+
+					if LockMode == 1 then
+						nodes[LockTo]:SetIcon(BoneTypeSort[nodes[LockTo].Type].Icon)
+						nodes[LockTo].Label:SetToolTip(BoneTypeSort[nodes[LockTo].Type].ToolTip)
+					end
+
 					LockMode = 1
 					LockTo = v.id
 
@@ -1954,12 +1960,18 @@ local function RGMBuildConstrainedEnts(parent, children, entpanel)
 						net.WriteBool(false)
 					net.SendToServer()
 				else
+
+					if LockMode == 2 then
+						conentnodes[LockTo]:SetIcon("icon16/brick_link.png")
+						conentnodes[LockTo].Label:SetToolTip(false)
+					end
+
 					LockMode = 2
 					LockTo = ent
 
 					surface.PlaySound("buttons/button9.wav")
 					conentnodes[ent]:SetIcon("icon16/brick_edit.png")
-					conentnodes[ent]:SetToolTip("#tool.ragdollmover.entlock")
+					conentnodes[ent].Label:SetToolTip("#tool.ragdollmover.entlock")
 				end
 			end
 		end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -414,7 +414,7 @@ end)
 
 net.Receive("rgmResetGizmo", function(len, pl)
 	if not pl.rgm then return end
-	pl.rgm.GizmoOffset = vector_origin
+	pl.rgm.GizmoOffset = Vector(0, 0, 0)
 
 	net.Start("rgmUpdateGizmo")
 	net.WriteVector(pl.rgm.GizmoOffset)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1541,8 +1541,8 @@ local function SetBoneNodes(bonepanel, ent, sortedbones)
 						nodes[LockTo]:SetIcon("icon16/lock.png")
 						nodes[LockTo].Label:SetToolTip("#tool.ragdollmover.lockedbone")
 					else
-						nodes[LockTo]:SetIcon(BoneTypeSort[v.Type].Icon)
-						nodes[LockTo].Label:SetToolTip(BoneTypeSort[v.Type].ToolTip)
+						nodes[LockTo]:SetIcon(BoneTypeSort[nodes[LockTo].Type].Icon)
+						nodes[LockTo].Label:SetToolTip(BoneTypeSort[nodes[LockTo].Type].ToolTip)
 					end
 				elseif LockMode == 2 then
 					net.Start("rgmLockConstrained")

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1336,7 +1336,8 @@ local function AddHBar(self) -- There is no horizontal scrollbars in gmod, so I 
 	self.HBar.btnUp.Paint = function(panel, w, h) derma.SkinHook("Paint", "ButtonLeft", panel, w, h) end
 	self.HBar.btnDown.Paint = function(panel, w, h) derma.SkinHook("Paint", "ButtonRight", panel, w, h) end
 
-	self.PanelWidth = 600
+	self.PanelWidth = 100
+	self.LastWidth = 1
 
 	self.HBar.SetScroll = function(self, scrll)
 		if (not self.Enabled) then self.Scroll = 0 return end
@@ -1438,7 +1439,7 @@ local function AddHBar(self) -- There is no horizontal scrollbars in gmod, so I 
 
 	self.PerformLayoutInternal = function(self)
 		local HTall, VTall = self:GetTall(), self.pnlCanvas:GetTall()
-		local HWide, VWide = self.pnlCanvas:GetWide(), self.PanelWidth
+		local HWide, VWide = self:GetWide(), self.PanelWidth
 		local XPos, YPos = 0, 0
 
 		self:Rebuild()
@@ -1456,13 +1457,15 @@ local function AddHBar(self) -- There is no horizontal scrollbars in gmod, so I 
 
 		self:Rebuild()
 
-		if (HWide ~= self.pnlCanvas:GetWide()) then
+		if (HWide ~= self.LastWidth) then
 			self.HBar:SetScroll(self.HBar:GetScroll())
 		end
 
 		if (VTall ~= self.pnlCanvas:GetTall()) then
 			self.VBar:SetScroll(self.VBar:GetScroll())
 		end
+
+		self.LastWidth = HWide
 	end
 
 	self.PerformLayout = function(self)
@@ -1737,13 +1740,13 @@ local function SetBoneNodes(bonepanel, ent, sortedbones)
 		end
 
 		local XSize = nodes[v.id].Label:GetTextSize()
-		local currentwidth = XSize + (v.depth * 20) + 32
+		local currentwidth = XSize + (v.depth * 17)
 		if currentwidth > width then
 			width = currentwidth
 		end
 	end
 
-	bonepanel:UpdateWidth(width)
+	bonepanel:UpdateWidth(width + 8 + 32 + 16)
 end
 
 local function RGMBuildBoneMenu(ent, bonepanel)
@@ -1862,7 +1865,7 @@ local function RGMBuildEntMenu(parent, children, entpanel)
 	end
 
 	local XSize = entnodes[parent].Label:GetTextSize()
-	width = XSize + 52
+	width = XSize + 17
 
 	local sortchildren = {depth = 1}
 
@@ -1901,7 +1904,7 @@ local function RGMBuildEntMenu(parent, children, entpanel)
 			end
 
 			XSize = entnodes[v].Label:GetTextSize()
-			local currentwidth = XSize + (depth * 20) + 32
+			local currentwidth = XSize + (depth * 17)
 
 			if currentwidth > width then
 				width = currentwidth
@@ -1913,7 +1916,7 @@ local function RGMBuildEntMenu(parent, children, entpanel)
 
 	MakeChildrenList(parent, sortchildren)
 
-	entpanel:UpdateWidth(width)
+	entpanel:UpdateWidth(width + 8 + 32)
 end
 
 local function RGMBuildConstrainedEnts(parent, children, entpanel)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -48,6 +48,7 @@ local function RGMGetBone(pl, ent, bone)
 	pl.rgm.IsPhysBone = false
 
 	local count = ent:GetPhysicsObjectCount()
+	local isragdoll = ent:GetClass() == "prop_ragdoll"
 
 	for i = 0, count - 1 do
 		local b = ent:TranslatePhysBoneToBone(i)
@@ -58,7 +59,7 @@ local function RGMGetBone(pl, ent, bone)
 	end
 
 	if count == 1 then
-		if (ent:GetClass() == "prop_physics" or ent:GetClass() == "prop_effect") and bone == 0 then
+		if not isragdoll and bone == 0 then
 			phys = 0
 			pl.rgm.IsPhysBone = true
 		end
@@ -67,7 +68,7 @@ local function RGMGetBone(pl, ent, bone)
 	local bonen = phys or bone
 
 	pl.rgm.PhysBone = bonen
-	if pl.rgm.IsPhysBone and not (ent:GetClass() == "prop_physics") then -- physics props only have 1 phys object which is tied to bone -1, and that bone doesn't really exist
+	if pl.rgm.IsPhysBone and isragdoll then -- physics props only have 1 phys object which is tied to bone -1, and that bone doesn't really exist
 		pl.rgm.Bone = ent:TranslatePhysBoneToBone(bonen)
 	else
 		pl.rgm.Bone = bonen
@@ -944,7 +945,7 @@ if SERVER then
 							obj:EnableMotion(true)
 							obj:Wake()
 						end
-						if ConstrainedAllowed:GetBool() then
+						if pl.rgmOffsetTable[i].locked and ConstrainedAllowed:GetBool() then
 							for lockent, bonetable in pairs(pl.rgmOffsetTable[i].locked) do
 								for j=0, lockent:GetPhysicsObjectCount()-1 do
 									if  bonetable[j].moving then

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -192,7 +192,7 @@ net.Receive("rgmLockBone", function(len, pl)
 
 	if not IsValid(ent) or ent:TranslateBoneToPhysBone(bone) == -1 then return end
 	if ent:GetClass() ~= "prop_ragdoll" then return end
-	bone = ent:TranslateBoneToPhysBone(bone)
+	bone = BoneToPhysBone(ent,bone)
 
 	if mode == 1 then
 		if not pl.rgmPosLocks[bone] then
@@ -245,8 +245,8 @@ net.Receive("rgmLockToBone", function(len, pl)
 	end
 
 	if not RecursiveFindIfParent(ent, lockedbone, lockorigin) then
-		local bone = ent:TranslateBoneToPhysBone(lockedbone)
-		lockorigin = ent:TranslateBoneToPhysBone(lockorigin)
+		local bone = rgm.BoneToPhysBone(ent,lockedbone)
+		lockorigin = rgm.BoneToPhysBone(ent,lockorigin)
 
 		pl.rgmBoneLocks[bone] = lockorigin
 		pl.rgmPosLocks[bone] = nil
@@ -265,7 +265,7 @@ end)
 net.Receive("rgmUnlockToBone", function(len, pl)
 	local unlockbone = net.ReadUInt(8)
 	local ent = pl.rgm.Entity
-	local bone = ent:TranslateBoneToPhysBone(unlockbone)
+	local bone = rgm.BoneToPhysBone(ent,unlockbone)
 
 	pl.rgmBoneLocks[bone] = nil
 

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -2124,8 +2124,8 @@ function TOOL.BuildCPanel(CPanel)
 
 		CCheckBox(Col4,"#tool.ragdollmover.scalechildren","ragdollmover_scalechildren")
 
-		CCheckBox(Col4, "Enable angle snapping", "ragdollmover_snapenable")
-		CNumSlider(Col4, "Angle snap amount", "ragdollmover_snapamount", 1, 180, 0)
+		CCheckBox(Col4, "#tool.ragdollmover.snapenable", "ragdollmover_snapenable")
+		CNumSlider(Col4, "#tool.ragdollmover.snapamount", "ragdollmover_snapamount", 1, 180, 0)
 
 		local ColBones = CCol(Col4, "#tool.ragdollmover.bonelist")
 			RGMMakeBoneButtonPanel(ColBones, CPanel)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -414,7 +414,7 @@ end)
 
 net.Receive("rgmResetGizmo", function(len, pl)
 	if not pl.rgm then return end
-	pl.rgm.GizmoOffset = Vector(0,0,0)
+	pl.rgm.GizmoOffset = vector_origin
 
 	net.Start("rgmUpdateGizmo")
 	net.WriteVector(pl.rgm.GizmoOffset)
@@ -439,9 +439,9 @@ net.Receive("rgmSetGizmoToBone", function(len, pl)
 	end
 
 	if axis.localizedoffset then
-		vector = WorldToLocal(vector, Angle(0,0,0), ent:GetPos(), ent:GetAngles())
+		vector = WorldToLocal(vector, angle_zero, ent:GetPos(), ent:GetAngles())
 	else
-		vector = WorldToLocal(vector, Angle(0,0,0), ent:GetPos(), Angle(0,0,0))
+		vector = WorldToLocal(vector, angle_zero, ent:GetPos(), angle_zero)
 	end
 
 	pl.rgm.GizmoOffset = vector
@@ -466,13 +466,13 @@ net.Receive("rgmResetAll", function(len, pl)
 
 	if net.ReadBool() then
 		RecursiveBoneFunc(bone, ent, function(bon)
-			ent:ManipulateBonePosition(bon, Vector(0, 0, 0))
-			ent:ManipulateBoneAngles(bon, Angle(0, 0, 0))
+			ent:ManipulateBonePosition(bon, vector_origin)
+			ent:ManipulateBoneAngles(bon, angle_zero)
 			ent:ManipulateBoneScale(bon, Vector(1, 1, 1))
 		end)
 	else
-		ent:ManipulateBonePosition(bone, Vector(0, 0, 0))
-		ent:ManipulateBoneAngles(bone, Angle(0, 0, 0))
+		ent:ManipulateBonePosition(bone, vector_origin)
+		ent:ManipulateBoneAngles(bone, angle_zero)
 		ent:ManipulateBoneScale(bone, Vector(1, 1, 1))
 	end
 
@@ -485,9 +485,9 @@ net.Receive("rgmResetPos", function(len, pl)
 	local ent = pl.rgm.Entity
 
 	if net.ReadBool() then
-		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBonePosition(bone, param) end, Vector(0, 0, 0))
+		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBonePosition(bone, param) end, vector_origin)
 	else
-		ent:ManipulateBonePosition(net.ReadUInt(8), Vector(0, 0, 0))
+		ent:ManipulateBonePosition(net.ReadUInt(8), vector_origin)
 	end
 
 	net.Start("rgmUpdateSliders")
@@ -499,9 +499,9 @@ net.Receive("rgmResetAng", function(len, pl)
 	local ent = pl.rgm.Entity
 
 	if net.ReadBool() then
-		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBoneAngles(bone, param) end, Angle(0, 0, 0))
+		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBoneAngles(bone, param) end, angle_zero)
 	else
-		ent:ManipulateBoneAngles(net.ReadUInt(8), Angle(0, 0, 0))
+		ent:ManipulateBoneAngles(net.ReadUInt(8), angle_zero)
 	end
 
 	net.Start("rgmUpdateSliders")
@@ -527,9 +527,9 @@ net.Receive("rgmScaleZero", function(len, pl)
 	local ent = pl.rgm.Entity
 
 	if net.ReadBool() then
-		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBoneScale(bone, param) end, Vector(0, 0, 0))
+		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBoneScale(bone, param) end, vector_origin)
 	else
-		ent:ManipulateBoneScale(net.ReadUInt(8), Vector(0, 0, 0))
+		ent:ManipulateBoneScale(net.ReadUInt(8), vector_origin)
 	end
 
 	net.Start("rgmUpdateSliders")
@@ -639,7 +639,7 @@ function TOOL:LeftClick(tr)
 		if SERVER then
 			local pl = self:GetOwner()
 			local axis, ent = pl.rgm.Axis, pl.rgm.Entity
-			local offset = Vector(0,0,0)
+			local offset = vector_origin
 
 			if not IsValid(axis) or not IsValid(ent) then self:SetOperation(0) return true end
 			offset = tr.HitPos
@@ -651,9 +651,9 @@ function TOOL:LeftClick(tr)
 			end
 
 			if axis.localizedoffset then
-				offset = WorldToLocal(offset, Angle(0,0,0), ent:GetPos(), ent:GetAngles())
+				offset = WorldToLocal(offset, angle_zero, ent:GetPos(), ent:GetAngles())
 			else
-				offset = WorldToLocal(offset, Angle(0,0,0), ent:GetPos(), Angle(0,0,0))
+				offset = WorldToLocal(offset, angle_zero, ent:GetPos(), angle_zero)
 			end
 
 			pl.rgm.GizmoOffset = offset
@@ -716,7 +716,7 @@ function TOOL:LeftClick(tr)
 			_, pl.rgmOffsetAng = WorldToLocal(apart:GetPos(),pang,apart:GetPos(),grabang)
 		end
 
-		pl.rgm.StartAngle = WorldToLocal(collision.hitpos, Angle(0,0,0), apart:GetPos(), apart:GetAngles())
+		pl.rgm.StartAngle = WorldToLocal(collision.hitpos, angle_zero, apart:GetPos(), apart:GetAngles())
 		if ent:GetClass() ~= "prop_ragdoll" and pl.rgm.IsPhysBone then
 			pl.rgm.Bone = 0
 		end
@@ -794,7 +794,7 @@ function TOOL:RightClick(tr)
 			local pl = self:GetOwner()
 			local axis = pl.rgm.Axis
 			local ent, rgment = tr.Entity, pl.rgm.Entity
-			local offset = Vector(0,0,0)
+			local offset = vector_origin
 
 			if not IsValid(axis) or not IsValid(rgment) then self:SetOperation(0) return true end
 
@@ -813,9 +813,9 @@ function TOOL:RightClick(tr)
 			end
 
 			if axis.localizedoffset then
-				offset = WorldToLocal(offset, Angle(0,0,0), rgment:GetPos(), rgment:GetAngles())
+				offset = WorldToLocal(offset, angle_zero, rgment:GetPos(), rgment:GetAngles())
 			else
-				offset = WorldToLocal(offset, Angle(0,0,0), rgment:GetPos(), Angle(0,0,0))
+				offset = WorldToLocal(offset, angle_zero, rgment:GetPos(), angle_zero)
 			end
 
 			pl.rgm.GizmoOffset = offset
@@ -2258,6 +2258,8 @@ local material = CreateMaterial("rgmGizmoMaterial", "UnlitGeneric", {
 	["$nocull"] = 		1,
 })
 
+local VECTOR_FRONT = Vector(1,0,0)
+
 function TOOL:DrawHUD()
 
 	local pl = LocalPlayer()
@@ -2285,7 +2287,7 @@ function TOOL:DrawHUD()
 				local fwd = (intersect-axis:GetPos())
 				fwd:Normalize()
 				axis:DrawDirectionLine(fwd,scale,false)
-				local dirnorm = pl.rgm.DirNorm or Vector(1,0,0)
+				local dirnorm = pl.rgm.DirNorm or VECTOR_FRONT
 				axis:DrawDirectionLine(dirnorm,scale,true)
 				axis:DrawAngleText(moveaxis, intersect, pl.rgm.StartAngle)
 			end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1701,6 +1701,9 @@ local function SetBoneNodes(bonepanel, ent, sortedbones)
 					if LockMode == 1 then
 						nodes[LockTo]:SetIcon(BoneTypeSort[nodes[LockTo].Type].Icon)
 						nodes[LockTo].Label:SetToolTip(BoneTypeSort[nodes[LockTo].Type].ToolTip)
+					elseif LockMode == 2 then
+						conentnodes[LockTo]:SetIcon("icon16/brick_link.png")
+						conentnodes[LockTo].Label:SetToolTip(false)
 					end
 
 					LockMode = 1
@@ -1961,7 +1964,10 @@ local function RGMBuildConstrainedEnts(parent, children, entpanel)
 					net.SendToServer()
 				else
 
-					if LockMode == 2 then
+					if LockMode == 1 then
+						nodes[LockTo]:SetIcon(BoneTypeSort[nodes[LockTo].Type].Icon)
+						nodes[LockTo].Label:SetToolTip(BoneTypeSort[nodes[LockTo].Type].ToolTip)
+					elseif LockMode == 2 then
 						conentnodes[LockTo]:SetIcon("icon16/brick_link.png")
 						conentnodes[LockTo].Label:SetToolTip(false)
 					end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -993,19 +993,29 @@ if SERVER then
 			snapamount = snapamount < 1 and 1 or snapamount
 		end
 
+		local tracepos = nil
+		if pl:KeyDown(IN_SPEED) then
+			local tr = util.TraceLine({
+				start = pl:EyePos(),
+				endpos = pl:EyePos() + pl:GetAimVector()*4096,
+				filter = {ent, pl}
+			})
+			tracepos = tr.HitPos
+		end
+
 		local physbonecount = ent:GetBoneCount() - 1
 		if physbonecount == nil then return end
 
 		if not scale then
-			if IsValid(ent:GetParent()) and bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not (ent:GetClass() == "prop_ragdoll") then
-				local pos, ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,0,snapamount,pl.rgm.StartAngle)
+			if IsValid(ent:GetParent()) and bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not (ent:GetClass() == "prop_ragdoll") then -- is parented
+				local pos, ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,0,snapamount,pl.rgm.StartAngle,nil,nil,nil,tracepos)
 				ent:SetLocalPos(pos)
 				ent:SetLocalAngles(ang)
-			elseif pl.rgm.IsPhysBone then
+			elseif pl.rgm.IsPhysBone then -- moving physbones
 
 				local isik,iknum = rgm.IsIKBone(self,ent,bone)
 
-				local pos,ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,1,snapamount,pl.rgm.StartAngle)
+				local pos,ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,1,snapamount,pl.rgm.StartAngle,nil,nil,nil,tracepos)
 
 				local obj = ent:GetPhysicsObjectNum(bone)
 				if not isik or iknum == 3 or (rotate and (iknum == 1 or iknum == 2)) then
@@ -1077,16 +1087,16 @@ if SERVER then
 				end
 
 				-- if not pl:GetNWBool("ragdollmover_keydown") then
-			else
-				local pos, ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,2,snapamount, pl.rgm.StartAngle, pl.rgm.NPhysBonePos, pl.rgm.NPhysBoneAng) -- if a bone is not physics one, we pass over "start angle" thing
+			else -- moving nonphysbones
+				local pos, ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,2,snapamount,pl.rgm.StartAngle,pl.rgm.NPhysBonePos,pl.rgm.NPhysBoneAng,nil,tracepos) -- if a bone is not physics one, we pass over "start angle" thing
 
 				ent:ManipulateBoneAngles(bone, ang)
 				ent:ManipulateBonePosition(bone, pos)
 			end
-		else
+		else -- scaling
 			bone = pl.rgm.Bone
 			local prevscale = ent:GetManipulateBoneScale(bone)
-			local sc, ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,2,snapamount, pl.rgm.StartAngle, pl.rgm.NPhysBonePos, pl.rgm.NPhysBoneAng, pl.rgm.NPhysBoneScale)
+			local sc, ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,2,snapamount,pl.rgm.StartAngle,pl.rgm.NPhysBonePos,pl.rgm.NPhysBoneAng,pl.rgm.NPhysBoneScale)
 
 			if axis.scalechildren then
 				local scalediff = sc - prevscale

--- a/lua/weapons/gmod_tool/stools/ragmover_ikchains.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_ikchains.lua
@@ -6,12 +6,6 @@ TOOL.ConfigName = ""
 
 TOOL.ClientConVar["type"] = 1
 
-if SERVER then
-
-util.AddNetworkString("rgmikMessage")
-
-end
-
 local ikchains_iktypes = {
 	"tool.ragmover_ikchains.ik1",
 	"tool.ragmover_ikchains.ik2",
@@ -29,12 +23,65 @@ local RGM_NOTIFY = {
 	BAD_ORDER = {id = 0, iserror = true},
 	SAME_BONE = {id = 1, iserror = true},
 	SUCCESS = {id = 2, iserror = false},
-	CHAINCLEARED = {id = 3, iserror = false}
+	CHAIN_CLEARED = {id = 3, iserror = false},
+	ENT_SELECTED = {id = 4, iserror = false},
+	SAVE_SUCCESS = {id = 5, iserror = false},
+	SAVE_FAIL = {id = 6, iserror = true},
+	LOAD_SUCCESS = {id = 7, iserror = false}
 }
+
+local function PrettifyMDLName(name)
+	local tablething = string.Explode("/", name)
+	name = tablething[#tablething]
+	name = string.sub(name, 1, -5)
+	return name
+end
 
 local function rgmSendNotif(message, pl)
 	net.Start("rgmikMessage")
 	net.WriteUInt(message,5)
+	net.Send(pl)
+end
+
+local function rgmSendBone(ent, physbone, pl)
+	net.Start("rgmikSendBone")
+	net.WriteEntity(ent)
+	net.WriteUInt(ent:TranslatePhysBoneToBone(physbone),10)
+	net.Send(pl)
+end
+
+local function rgmCallReset(pl)
+	net.Start("rgmikReset")
+	net.Send(pl)
+end
+
+local function rgmSendPhysBones(ent)
+	local num = ent:GetPhysicsObjectCount()
+
+	net.WriteUInt(num, 10)
+
+	for i = 0, num do
+		net.WriteUInt(ent:TranslatePhysBoneToBone(i), 10)
+
+		local parent = rgm.GetPhysBoneParent(ent, i)
+		parent = not parent and 1023 or ent:TranslatePhysBoneToBone(parent) -- 512 should be the absolute maximum bone amount, with those .dmx that sfm has
+		net.WriteUInt(parent, 10)
+	end
+end
+
+local function rgmReceivePhysBones()
+	local bones = {}
+
+	for i = 0, net.ReadUInt(10) do
+		bones[net.ReadUInt(10)] = net.ReadUInt(10)
+	end
+
+	return bones
+end
+
+local function rgmSendEnt(ent, pl)
+	net.Start("rgmikSendEnt")
+	net.WriteEntity(ent)
 	net.Send(pl)
 end
 
@@ -46,6 +93,78 @@ local function RecursionBoneFind(ent, startbone, lookfor)
 	return RecursionBoneFind(ent, nextbone, lookfor)
 end
 
+if SERVER then
+
+util.AddNetworkString("rgmikMessage")
+util.AddNetworkString("rgmikAimedBone")
+util.AddNetworkString("rgmikSendBone")
+util.AddNetworkString("rgmikReset")
+util.AddNetworkString("rgmikSendEnt")
+util.AddNetworkString("rgmikRequestSave")
+util.AddNetworkString("rgmikSave")
+util.AddNetworkString("rgmikLoad")
+
+
+net.Receive("rgmikRequestSave", function(len, pl)
+	local tool = pl:GetTool("ragmover_ikchains")
+	if not tool then return end
+
+	local ent = tool.SelectedSaveEnt
+	if not ent or not ent.rgmIKChains then rgmSendNotif(6, pl) return end
+
+	local num = 0
+	local iks = {}
+
+	for type, iktable in pairs(ent.rgmIKChains) do
+		num = num + 1
+		iks[num] = iktable
+	end
+
+	net.Start("rgmikSave")
+
+	net.WriteEntity(ent)
+	net.WriteUInt(num,4)
+
+	for i = 1, num do
+		net.WriteUInt(iks[i].type, 4)
+		net.WriteUInt(ent:TranslatePhysBoneToBone(iks[i].hip), 10)
+		net.WriteUInt(ent:TranslatePhysBoneToBone(iks[i].knee), 10)
+		net.WriteUInt(ent:TranslatePhysBoneToBone(iks[i].foot), 10)
+	end
+
+	net.Send(pl)
+end)
+
+net.Receive("rgmikLoad", function(len, pl)
+	local num = net.ReadUInt(4)
+	local iktable = {}
+
+	for i = 1, num do
+		iktable[i] = {}
+		iktable[i].type = net.ReadUInt(4)
+		iktable[i].hip = net.ReadUInt(10)
+		iktable[i].knee = net.ReadUInt(10)
+		iktable[i].foot = net.ReadUInt(10)
+	end
+
+	local tool = pl:GetTool("ragmover_ikchains")
+	if not tool then return end
+
+	local ent = tool.SelectedSaveEnt
+	if not ent then return end
+
+	ent.rgmIKChains = {}
+
+	for k, ik in ipairs(iktable) do
+		if ik.hip == 1023 or ik.knee == 1023 or ik.foot == 1023 then continue end
+		table.insert(ent.rgmIKChains, {hip = rgm.BoneToPhysBone(ent, ik.hip), knee = rgm.BoneToPhysBone(ent, ik.knee), foot = rgm.BoneToPhysBone(ent, ik.foot), type = ik.type})
+	end
+
+	rgmSendNotif(7, pl)
+end)
+
+end
+
 function TOOL:LeftClick(tr)
 	if not IsValid(tr.Entity) or tr.Entity:GetClass() ~= "prop_ragdoll" or not tr.PhysicsBone then return false end
 	local stage = self:GetStage()
@@ -54,6 +173,11 @@ function TOOL:LeftClick(tr)
 		self.SelectedEnt = tr.Entity
 		self.SelectedHip = tr.PhysicsBone
 		self.SelectedKnee = nil
+
+		if SERVER then
+			rgmSendBone(tr.Entity, tr.PhysicsBone, self:GetOwner())
+		end
+
 		self:SetStage(1)
 		return true
 	elseif stage == 1 then
@@ -64,6 +188,11 @@ function TOOL:LeftClick(tr)
 		end
 
 		self.SelectedKnee = tr.PhysicsBone
+
+		if SERVER then
+			rgmSendBone(tr.Entity, tr.PhysicsBone, self:GetOwner())
+		end
+
 		self:SetStage(2)
 		return true
 	else
@@ -74,17 +203,25 @@ function TOOL:LeftClick(tr)
 		end
 
 		if RecursionBoneFind(self.SelectedEnt, tr.PhysicsBone, self.SelectedKnee) and RecursionBoneFind(self.SelectedEnt, self.SelectedKnee, self.SelectedHip) then
-			if SERVER then rgmSendNotif(RGM_NOTIFY.SUCCESS.id, self:GetOwner()) end
+			if SERVER then 
+				rgmSendNotif(RGM_NOTIFY.SUCCESS.id, self:GetOwner())
+				rgmCallReset(self:GetOwner())
+			end
+
 			if not tr.Entity.rgmIKChains then tr.Entity.rgmIKChains = {} end
 			local Type = self:GetClientNumber("type",1)
-			Type = math.ceil(Type)
 			tr.Entity.rgmIKChains[Type] = {hip = self.SelectedHip,knee = self.SelectedKnee,foot = tr.PhysicsBone,type = Type}
 			self:SetStage(0)
+			rgmCallReset(self:GetOwner())
 			self.SelectedHip = nil
 			self.SelectedKnee = nil
 			return true
 		else
-			if SERVER then rgmSendNotif(RGM_NOTIFY.BAD_ORDER.id, self:GetOwner()) end
+			if SERVER then 
+				rgmSendNotif(RGM_NOTIFY.BAD_ORDER.id, self:GetOwner())
+				rgmCallReset(self:GetOwner())
+			end
+
 			self:SetStage(0)
 			self.SelectedHip = nil
 			self.SelectedKnee = nil
@@ -95,18 +232,33 @@ function TOOL:LeftClick(tr)
 end
 
 function TOOL:RightClick(tr)
-	
+	local ent = tr.Entity
+
+	if ent:GetClass() == "prop_ragdoll" then
+		if SERVER then
+			if self.SelectedSaveEnt == ent then return false end
+			rgmSendEnt(ent, self:GetOwner())
+			self.SelectedSaveEnt = ent
+
+			rgmSendNotif(RGM_NOTIFY.ENT_SELECTED.id, self:GetOwner())
+		end
+
+		return true
+	end
+
+	return false
 end
 
 function TOOL:Reload(tr)
 	if self:GetStage() == 0 then
 		local Type = self:GetClientNumber("type",1)
 		if tr.Entity.rgmIKChains and tr.Entity.rgmIKChains[Type] then
-			if SERVER then rgmSendNotif(RGM_NOTIFY.CHAINCLEARED.id, self:GetOwner()) end
+			if SERVER then rgmSendNotif(RGM_NOTIFY.CHAIN_CLEARED.id, self:GetOwner()) end
 			tr.Entity.rgmIKChains[Type] = nil
 		end
 		return true
 	else
+		if SERVER then rgmCallReset(self:GetOwner()) end
 		self:SetStage(0)
 		self.SelectedHip = nil
 		self.SelectedKnee = nil
@@ -115,17 +267,107 @@ function TOOL:Reload(tr)
 end
 
 if SERVER then
+local PrevEnt = {}
 
 function TOOL:Think()
-	local tr = self:GetOwner():GetEyeTrace()
+	local pl = self:GetOwner()
+	local tr = pl:GetEyeTrace()
 	if IsValid(tr.Entity) and tr.Entity:GetClass() == "prop_ragdoll" then
-		self:GetOwner():SetNWInt("ragdollmoverik_aimedbone",tr.Entity:TranslatePhysBoneToBone(tr.PhysicsBone))
+		net.Start("rgmikAimedBone")
+		net.WriteUInt(tr.Entity:TranslatePhysBoneToBone(tr.PhysicsBone),10)
+
+		if PrevEnt[pl] ~= tr.Entity then
+			net.WriteBool(true)
+			rgmSendPhysBones(tr.Entity)
+		else
+			net.WriteBool(false)
+		end
+
+		net.Send(pl)
+		PrevEnt[pl] = tr.Entity
 	end
 end
 
 end
 
 if CLIENT then
+
+local IK_DIR = "rgmik"
+
+local SelectedEntName = "none"
+local SelectedEnt = nil
+local ChainSavePanel = nil
+
+local function ChainSaver(cpanel)
+	local main = vgui.Create("DPanel")
+	main:SetTall(45)
+
+	main.selector = vgui.Create("DComboBox", main)
+
+	if not file.Exists(IK_DIR, "DATA") then file.CreateDir(IK_DIR) end
+	local files = file.Find(IK_DIR .. "/*.txt", "DATA")
+	for k, file in ipairs(files) do
+		main.selector:AddChoice(string.sub(file, 1, -5))
+	end
+
+	main.save = vgui.Create("DButton", main)
+	main.save:SetText("Save")
+	main.save.DoClick = function()
+		net.Start("rgmikRequestSave")
+		net.SendToServer()
+	end
+
+	main.load = vgui.Create("DButton", main)
+	main.load:SetText("Load")
+	main.load.DoClick = function()
+		if not SelectedEnt then return end
+
+		local name = main.selector:GetSelected()
+		if not name then return end
+		if not file.Exists(IK_DIR, "DATA") or not file.Exists(IK_DIR .. "/" .. name .. ".txt", "DATA") then return end
+
+		local json = file.Read(IK_DIR .. "/" .. name .. ".txt", "DATA")
+		local iktable = util.JSONToTable(json)
+
+		net.Start("rgmikLoad")
+		net.WriteUInt(#iktable, 4)
+		for k, ik in ipairs(iktable) do
+			net.WriteUInt(ik.type, 4)
+			net.WriteUInt(SelectedEnt:LookupBone(ik.hip) or 1023, 10)
+			net.WriteUInt(SelectedEnt:LookupBone(ik.knee) or 1023, 10)
+			net.WriteUInt(SelectedEnt:LookupBone(ik.foot) or 1023, 10)
+		end
+		net.SendToServer()
+	end
+
+	main.label = vgui.Create("DLabel")
+	main.label:SetDark(true)
+
+	main.PerformLayout = function()
+		main.selector:SetPos(0,0)
+		main.selector:SetSize(main:GetWide(),20)
+
+		main.save:SetPos(0,25)
+		main.save:SetSize(main:GetWide()/2 - 20,20)
+
+		main.load:SetPos(main:GetWide()/2 + 20,25)
+		main.load:SetSize(main:GetWide()/2 - 20,20)
+	end
+
+	main.SetText = function(self, text)
+		self.label:SetText("Selected ragdoll: " .. text)
+		self.label:SizeToContents()
+	end
+
+	main.AddChoice = function(self, option)
+		self.selector:AddChoice(option)
+	end
+
+	cpanel:AddItem(main)
+	cpanel:AddItem(main.label)
+
+	return main
+end
 
 local function LimbSelection(cpanel)
 	local main = vgui.Create("DPanel")
@@ -190,7 +432,9 @@ end
 
 function TOOL.BuildCPanel(CPanel)
 
+	ChainSavePanel = ChainSaver(CPanel)
 	LimbSelection(CPanel)
+	ChainSavePanel:SetText(SelectedEntName)
 
 end
 
@@ -198,21 +442,45 @@ function TOOL:DrawHUD()
 
 	local pl = LocalPlayer()
 
-	local tr = pl:GetEyeTrace()
-	if IsValid(tr.Entity) and (tr.Entity:GetClass() == "prop_ragdoll") then
-		local aimedbone = pl:GetNWInt("ragdollmoverik_aimedbone",0)
-		rgm.DrawBoneName(tr.Entity,aimedbone)
-	end
---[[	if self:GetStage() > 0 then
-		if IsValid(self.SelectedEnt) then
-			if self.SelectedHip then
-				rgm.DrawBoneName(self.SelectedEnt,self.SelectedEnt:TranslatePhysBoneToBone(self.SelectedHip))
-			end
-			if self.SelectedKnee then
-				rgm.DrawBoneName(self.SelectedEnt,self.SelectedEnt:TranslatePhysBoneToBone(self.SelectedKnee))
+	local aimedent = pl:GetEyeTrace().Entity
+
+	if IsValid(aimedent) and (aimedent:GetClass() == "prop_ragdoll") then
+
+		if pl.ragdollmoverik_aimedskeleton then
+			for bone, pbone in pairs(pl.ragdollmoverik_aimedskeleton) do
+				local pos = aimedent:GetBonePosition(bone)
+				pos = pos:ToScreen()
+
+				if pbone ~= 1023 then
+					local ppos = aimedent:GetBonePosition(pbone)
+					ppos = ppos:ToScreen()
+					surface.SetDrawColor( 255, 255, 255, 255 )
+					surface.DrawLine(ppos.x, ppos.y, pos.x, pos.y)
+				end
+
+				surface.DrawCircle(pos.x, pos.y, 2.5, Color(0,200,0,255))
 			end
 		end
-	end]]
+
+		local aimedbone = pl.ragdollmoverik_aimedbone or 0
+		if aimedbone ~= pl.ragdollmoverik_hip and aimedbone ~= pl.ragdollmoverik_knee or aimedent ~= pl.ragdollmoverik_ent then
+			rgm.DrawBoneName(aimedent,aimedbone)
+		end
+
+	end
+
+	local iktype = self:GetClientNumber("type",1)
+	iktype = ((iktype == 3) or (iktype == 4)) and true or false
+
+	if pl.ragdollmoverik_ent and pl.ragdollmoverik_hip then
+		local hipname = iktype and "#tool.ragmover_ikchains.upperarm" or "#tool.ragmover_ikchains.hip"
+		rgm.DrawBoneName(pl.ragdollmoverik_ent,pl.ragdollmoverik_hip,hipname)
+	end
+
+	if pl.ragdollmoverik_ent and pl.ragdollmoverik_knee then
+		local kneename = iktype and "#tool.ragmover_ikchains.elbow" or "#tool.ragmover_ikchains.knee"
+		rgm.DrawBoneName(pl.ragdollmoverik_ent,pl.ragdollmoverik_knee,kneename)
+	end
 
 end
 
@@ -239,6 +507,87 @@ end
 net.Receive("rgmikMessage", function(len)
 	local message = net.ReadUInt(5)
 	rgmDoNotification(message)
+end)
+
+net.Receive("rgmikAimedBone", function(len)
+	local pl = LocalPlayer()
+	pl.ragdollmoverik_aimedbone = net.ReadUInt(10)
+
+	if net.ReadBool() then
+		pl.ragdollmoverik_aimedskeleton = rgmReceivePhysBones()
+	end
+end)
+
+net.Receive("rgmikSendBone", function(len)
+	local ent = net.ReadEntity()
+	local bone = net.ReadUInt(10)
+	local pl = LocalPlayer()
+	local tool = pl:GetTool("ragmover_ikchains")
+	if not tool then return end
+
+	local stage = tool:GetStage()
+	if stage == 0 then
+		pl.ragdollmoverik_ent = ent
+		pl.ragdollmoverik_hip = bone
+	elseif stage == 1 then
+		if ent ~= pl.ragdollmoverik_ent then return end
+		pl.ragdollmoverik_knee = bone
+	end
+end)
+
+net.Receive("rgmikReset", function(len)
+	local pl = LocalPlayer()
+	pl.ragdollmoverik_ent = nil
+	pl.ragdollmoverik_hip = nil
+	pl.ragdollmoverik_knee = nil
+end)
+
+net.Receive("rgmikSendEnt", function(len)
+	SelectedEnt = net.ReadEntity()
+	local pname = PrettifyMDLName(SelectedEnt:GetModel())
+
+	SelectedEntName = "[" .. SelectedEnt:EntIndex() .. "] " .. pname
+
+	if ChainSavePanel then
+		ChainSavePanel:SetText(SelectedEntName)
+	end
+end)
+
+net.Receive("rgmikSave", function(len)
+	local iktable = {}
+	local ent = net.ReadEntity()
+
+	for i = 1, net.ReadUInt(4) do
+		iktable[i] = {}
+		iktable[i].type = net.ReadUInt(4)
+		iktable[i].hip = ent:GetBoneName(net.ReadUInt(10))
+		iktable[i].knee = ent:GetBoneName(net.ReadUInt(10))
+		iktable[i].foot = ent:GetBoneName(net.ReadUInt(10))
+	end
+
+	local json = util.TableToJSON(iktable, true)
+	if not file.Exists(IK_DIR, "DATA") then file.CreateDir(IK_DIR) end
+
+	local name = PrettifyMDLName(ent:GetModel())
+	if file.Exists(IK_DIR .. "/" .. name .. ".txt", "DATA") then
+		local exists = true
+		local count = 1
+
+		while exists do
+			local newname = name .. count
+
+			if not file.Exists(IK_DIR .. "/" .. newname .. ".txt", "DATA") then
+				name = newname
+				exists = false
+			end
+
+			count = count + 1
+		end
+	end
+
+	file.Write(IK_DIR .. "/" .. name .. ".txt", json)
+	ChainSavePanel:AddChoice(name)
+	rgmDoNotification(5)
 end)
 
 end

--- a/lua/weapons/gmod_tool/stools/ragmover_ikchains.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_ikchains.lua
@@ -6,54 +6,110 @@ TOOL.ConfigName = ""
 
 TOOL.ClientConVar["type"] = 1
 
+if SERVER then
+
+util.AddNetworkString("rgmikMessage")
+
+end
+
 local ikchains_iktypes = {
 	"tool.ragmover_ikchains.ik1",
 	"tool.ragmover_ikchains.ik2",
 	"tool.ragmover_ikchains.ik3",
-	"tool.ragmover_ikchains.ik4"
+	"tool.ragmover_ikchains.ik4",
+	"tool.ragmover_ikchains.ik5",
+	"tool.ragmover_ikchains.ik6",
+	"tool.ragmover_ikchains.ik7",
+	"tool.ragmover_ikchains.ik8",
+	"tool.ragmover_ikchains.ik9",
+	"tool.ragmover_ikchains.ik10"
 }
 
-local function Message(ply,text,icon,sound)
-	if SERVER then
-		ply:SendLua("GAMEMODE:AddNotify('"..text.."', "..icon..", 5)")
-		ply:SendLua("surface.PlaySound('"..sound.."')")
-	end
+local RGM_NOTIFY = {
+	BAD_ORDER = {id = 0, iserror = true},
+	SAME_BONE = {id = 1, iserror = true},
+	SUCCESS = {id = 2, iserror = false},
+	CHAINCLEARED = {id = 3, iserror = false}
+}
+
+local function rgmSendNotif(message, pl)
+	net.Start("rgmikMessage")
+	net.WriteUInt(message,5)
+	net.Send(pl)
+end
+
+local function RecursionBoneFind(ent, startbone, lookfor)
+	local nextbone = rgm.GetPhysBoneParent(ent, startbone)
+	if not nextbone then return false end
+
+	if nextbone == lookfor then return true end
+	return RecursionBoneFind(ent, nextbone, lookfor)
 end
 
 function TOOL:LeftClick(tr)
 	if not IsValid(tr.Entity) or tr.Entity:GetClass() ~= "prop_ragdoll" or not tr.PhysicsBone then return false end
-	if self:GetStage() == 0 then
+	local stage = self:GetStage()
+
+	if stage == 0 then
 		self.SelectedEnt = tr.Entity
-		self.SelectedBone = tr.PhysicsBone
+		self.SelectedHip = tr.PhysicsBone
+		self.SelectedKnee = nil
 		self:SetStage(1)
+		return true
+	elseif stage == 1 then
+		if tr.Entity ~= self.SelectedEnt then return false end
+		if self.SelectedHip == tr.PhysicsBone then
+			if SERVER then rgmSendNotif(RGM_NOTIFY.SAME_BONE.id, self:GetOwner()) end
+			return false
+		end
+
+		self.SelectedKnee = tr.PhysicsBone
+		self:SetStage(2)
 		return true
 	else
 		if tr.Entity ~= self.SelectedEnt then return false end
-		local kneebone = rgm.GetPhysBoneParent(tr.Entity,tr.PhysicsBone)
-		if rgm.GetPhysBoneParent(tr.Entity,kneebone) == self.SelectedBone then
+		if self.SelectedHip == tr.PhysicsBone or self.SelectedKnee == tr.PhysicsBone then
+			if SERVER then rgmSendNotif(RGM_NOTIFY.SAME_BONE.id, self:GetOwner()) end
+			return false
+		end
+
+		if RecursionBoneFind(self.SelectedEnt, tr.PhysicsBone, self.SelectedKnee) and RecursionBoneFind(self.SelectedEnt, self.SelectedKnee, self.SelectedHip) then
+			if SERVER then rgmSendNotif(RGM_NOTIFY.SUCCESS.id, self:GetOwner()) end
 			if not tr.Entity.rgmIKChains then tr.Entity.rgmIKChains = {} end
 			local Type = self:GetClientNumber("type",1)
 			Type = math.ceil(Type)
-			tr.Entity.rgmIKChains[Type] = {hip = self.SelectedBone,knee = kneebone,foot = tr.PhysicsBone,type = Type}
+			tr.Entity.rgmIKChains[Type] = {hip = self.SelectedHip,knee = self.SelectedKnee,foot = tr.PhysicsBone,type = Type}
+			self:SetStage(0)
+			self.SelectedHip = nil
+			self.SelectedKnee = nil
+			return true
 		else
-			Message(self:GetOwner(),"#tool.ragmover_ikchains.error",1,"buttons/button8.wav")
+			if SERVER then rgmSendNotif(RGM_NOTIFY.BAD_ORDER.id, self:GetOwner()) end
+			self:SetStage(0)
+			self.SelectedHip = nil
+			self.SelectedKnee = nil
+			return false
 		end
-		self:SetStage(0)
-		return true
 	end
 	return false
 end
 
 function TOOL:RightClick(tr)
+	
+end
+
+function TOOL:Reload(tr)
 	if self:GetStage() == 0 then
 		local Type = self:GetClientNumber("type",1)
 		if tr.Entity.rgmIKChains and tr.Entity.rgmIKChains[Type] then
+			if SERVER then rgmSendNotif(RGM_NOTIFY.CHAINCLEARED.id, self:GetOwner()) end
 			tr.Entity.rgmIKChains[Type] = nil
 		end
 		return true
 	else
 		self:SetStage(0)
-		return true
+		self.SelectedHip = nil
+		self.SelectedKnee = nil
 	end
 	return false
 end
@@ -71,14 +127,70 @@ end
 
 if CLIENT then
 
+local function LimbSelection(cpanel)
+	local main = vgui.Create("DPanel")
+	main:SetTall(200)
+
+	local buttons = {}
+
+	for k, v in ipairs(ikchains_iktypes) do
+		buttons[k] = vgui.Create("DButton", main)
+
+		buttons[k]:SetText("#" .. v)
+
+		buttons[k].DoClick = function()
+			RunConsoleCommand("ragmover_ikchains_type", k)
+			main.text:SetText(language.GetPhrase("tool.ragmover_ikchains.ikslot") .. " " .. language.GetPhrase(ikchains_iktypes[k]))
+		end
+
+		buttons[k].PerformLayout = function(self)
+			local x, y, tall
+
+			if (k % 2) ~= 0 then
+				x = 0
+			else
+				x = main:GetWide() / 2 + 5
+			end
+
+			if k == 1 or k == 2 then
+				y = 55
+			elseif k < 5 then
+				y = 0
+			else
+				y = 130 + (math.ceil((k - 4) / 2) - 1)*25
+			end
+
+			if k > 4 then
+				tall = 20
+			else
+				tall = 50
+			end
+
+			self:SetPos(x,y)
+			self:SetSize(main:GetWide() / 2 - 5, tall)
+		end
+	end
+
+	main.text = vgui.Create("DLabel", cpanel)
+
+	local id = GetConVar("ragmover_ikchains_type"):GetInt() ~= 0 and GetConVar("ragmover_ikchains_type"):GetInt() or 1
+	main.text:SetText(language.GetPhrase("tool.ragmover_ikchains.ikslot") .. " " .. language.GetPhrase(ikchains_iktypes[id]))
+	main.text:SetDark(true)
+	main.text:SizeToContents()
+
+	main.PerformLayout = function(self)
+		for k, v in ipairs(ikchains_iktypes) do
+			buttons[k]:PerformLayout()
+		end
+	end
+
+	cpanel:AddItem(main)
+	cpanel:AddItem(main.text)
+end
+
 function TOOL.BuildCPanel(CPanel)
 
-	local s = CPanel:NumSlider(language.GetPhrase("tool.ragmover_ikchains.ikslot") .. " " .. language.GetPhrase(ikchains_iktypes[1]),"ragmover_ikchains_type",1,4,0)
-	s:SetValue(0)
-	s.ValueChanged = function(self,val)
-		RunConsoleCommand("ragmover_ikchains_type",math.Round(self:GetValue()))
-		self:SetText(language.GetPhrase("tool.ragmover_ikchains.ikslot") .. " " .. language.GetPhrase(ikchains_iktypes[math.Round(self:GetValue())]))
-	end
+	LimbSelection(CPanel)
 
 end
 
@@ -91,7 +203,42 @@ function TOOL:DrawHUD()
 		local aimedbone = pl:GetNWInt("ragdollmoverik_aimedbone",0)
 		rgm.DrawBoneName(tr.Entity,aimedbone)
 	end
+--[[	if self:GetStage() > 0 then
+		if IsValid(self.SelectedEnt) then
+			if self.SelectedHip then
+				rgm.DrawBoneName(self.SelectedEnt,self.SelectedEnt:TranslatePhysBoneToBone(self.SelectedHip))
+			end
+			if self.SelectedKnee then
+				rgm.DrawBoneName(self.SelectedEnt,self.SelectedEnt:TranslatePhysBoneToBone(self.SelectedKnee))
+			end
+		end
+	end]]
 
 end
+
+local function rgmDoNotification(message)
+	local MessageTable = {}
+
+	for key, data in pairs(RGM_NOTIFY) do
+		if not data.iserror then
+			MessageTable[data.id] = function()
+				notification.AddLegacy("#tool.ragmover_ikchains.message" .. data.id, NOTIFY_GENERIC, 5)
+				surface.PlaySound("buttons/button14.wav")
+			end
+		else
+			MessageTable[data.id] = function()
+				notification.AddLegacy("#tool.ragmover_ikchains.message" .. data.id, NOTIFY_ERROR, 5)
+				surface.PlaySound("buttons/button10.wav")
+			end
+		end
+	end
+
+	MessageTable[message]()
+end
+
+net.Receive("rgmikMessage", function(len)
+	local message = net.ReadUInt(5)
+	rgmDoNotification(message)
+end)
 
 end

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -116,13 +116,25 @@ tool.ragdollmover.entlock=Select a physical bone from bone list to lock this ent
 tool.ragmover_ikchains.name=Ragdoll Mover - IK Chains
 tool.ragmover_ikchains.name2=Rag Mover - IK Chains
 tool.ragmover_ikchains.desc=Make your own IK chains for ragdolls to be used with Ragdoll Mover.
-tool.ragmover_ikchains.0=Left click to select IK hip/upperarm bone.
-tool.ragmover_ikchains.1=Now left click again to select foot/hand bone.
+tool.ragmover_ikchains.0=Left click to select IK hip/upperarm bone. Right click to apply saved IK rig on a ragdoll.
+tool.ragmover_ikchains.1=Left click again to select knee/elbow bone.
+tool.ragmover_ikchains.2=Now left click again to select foot/hand bone.
+
+tool.ragmover_ikchains.message0=Bad bone order, resetting the setup process
+tool.ragmover_ikchains.message1=This bone was already selected to be some other part of the IK
+tool.ragmover_ikchains.message2=IK chain set!
+tool.ragmover_ikchains.message3=IK chain cleared!
 
 tool.ragmover_ikchains.ik1=Left Leg
 tool.ragmover_ikchains.ik2=Right Leg
 tool.ragmover_ikchains.ik3=Left Arm
 tool.ragmover_ikchains.ik4=Right Arm
+tool.ragmover_ikchains.ik5=Additional slot 1
+tool.ragmover_ikchains.ik6=Additional slot 2
+tool.ragmover_ikchains.ik7=Additional slot 3
+tool.ragmover_ikchains.ik8=Additional slot 4
+tool.ragmover_ikchains.ik9=Additional slot 5
+tool.ragmover_ikchains.ik10=Additional slot 6
 
 tool.ragmover_ikchains.error=There can be only one knee bone.
 

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -78,8 +78,13 @@ tool.ragdollmover.unlockang=Unlock Rotation
 tool.ragdollmover.lockbone=Lock to this Bone
 tool.ragdollmover.unlockbone=Unlock this Bone
 
-tool.ragdollmover.lockbonesuccess=Bone locked successfully!
-tool.ragdollmover.lockboneerror=Failed to do a bone lock!
+tool.ragdollmover.message0=Can't lock bone to its parent bone, how would that even work?
+tool.ragdollmover.message1=Bone locked successfully!
+tool.ragdollmover.message2=Can't lock nonphysical bones! Good luck calculating rotations of those!
+tool.ragdollmover.message3=Can't lock bone to itself, that would be weird!
+tool.ragdollmover.message4=Can't lock entity to nonphysical bones!
+tool.ragdollmover.message5=Entity locking is not allowed here!
+tool.ragdollmover.message6=Entity locked successfully!
 
 tool.ragdollmover.putgizmopos=Put Gizmo offset here
 
@@ -88,6 +93,8 @@ tool.ragdollmover.listshowall=All
 tool.ragdollmover.listshowphys=Phys
 tool.ragdollmover.listshownonphys=Nonphys
 tool.ragdollmover.entchildren=Entity Children
+tool.ragdollmover.conents=Constrained Entities
+tool.ragdollmover.conentshelp=This tree lists entities that are constrained to the selected entity. Click on the entities to lock them to the selected entity.\nIf your currently selected entity is a ragdoll, then you must specify (via the bone list) to which bone you want entities to be locked to.
 
 tool.ragdollmover.physbone=Physical Bone
 tool.ragdollmover.lockedbone=Locked Physical Bone

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -31,7 +31,9 @@ tool.ragdollmover.ik3=Left Hand IK
 tool.ragdollmover.ik4=Right Hand IK
 tool.ragdollmover.ik1=Left Leg IK
 tool.ragdollmover.ik2=Right Leg IK
+tool.ragdollmover.ikchain=Chain
 tool.ragdollmover.ikall=Select/Deselect All
+tool.ragdollmover.additional=Additional IK Chains
 
 tool.ragdollmover.miscpanel=Misc
 tool.ragdollmover.unfreeze=Unfreeze on release
@@ -135,7 +137,5 @@ tool.ragmover_ikchains.ik7=Additional slot 3
 tool.ragmover_ikchains.ik8=Additional slot 4
 tool.ragmover_ikchains.ik9=Additional slot 5
 tool.ragmover_ikchains.ik10=Additional slot 6
-
-tool.ragmover_ikchains.error=There can be only one knee bone.
 
 tool.ragmover_ikchains.ikslot=IK slot:

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -75,6 +75,11 @@ tool.ragdollmover.lockpos=Lock Position
 tool.ragdollmover.unlockpos=Unlock Position
 tool.ragdollmover.lockang=Lock Rotation
 tool.ragdollmover.unlockang=Unlock Rotation
+tool.ragdollmover.lockbone=Lock to this Bone
+tool.ragdollmover.unlockbone=Unlock this Bone
+
+tool.ragdollmover.lockbonesuccess=Bone locked successfully!
+tool.ragdollmover.lockboneerror=Failed to do a bone lock!
 
 tool.ragdollmover.putgizmopos=Put Gizmo offset here
 
@@ -89,6 +94,7 @@ tool.ragdollmover.lockedbone=Locked Physical Bone
 tool.ragdollmover.nonphysbone=Nonphysical Bone
 tool.ragdollmover.proceduralbone=Procedural Bone
 tool.ragdollmover.parentedbone=Parented Bone
+tool.ragdollmover.lockedbonetobone=Physical Bone locked to another bone
 
 
 tool.ragmover_ikchains.name=Ragdoll Mover - IK Chains

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -118,7 +118,7 @@ tool.ragdollmover.entlock=Select a physical bone from bone list to lock this ent
 tool.ragmover_ikchains.name=Ragdoll Mover - IK Chains
 tool.ragmover_ikchains.name2=Rag Mover - IK Chains
 tool.ragmover_ikchains.desc=Make your own IK chains for ragdolls to be used with Ragdoll Mover.
-tool.ragmover_ikchains.0=Left click to select IK hip/upperarm bone. Right click to apply saved IK rig on a ragdoll.
+tool.ragmover_ikchains.0=Left click to select IK hip/upperarm bone. Right click to select a ragdoll for saving/loading IK chains on.
 tool.ragmover_ikchains.1=Left click again to select knee/elbow bone.
 tool.ragmover_ikchains.2=Now left click again to select foot/hand bone.
 
@@ -126,6 +126,10 @@ tool.ragmover_ikchains.message0=Bad bone order, resetting the setup process
 tool.ragmover_ikchains.message1=This bone was already selected to be some other part of the IK
 tool.ragmover_ikchains.message2=IK chain set!
 tool.ragmover_ikchains.message3=IK chain cleared!
+tool.ragmover_ikchains.message4=Entity selected!
+tool.ragmover_ikchains.message5=Save successful!
+tool.ragmover_ikchains.message6=Save failed. Make sure you have a ragdoll with existing IK chains selected!
+tool.ragmover_ikchains.message7=IK Chain loaded!
 
 tool.ragmover_ikchains.ik1=Left Leg
 tool.ragmover_ikchains.ik2=Right Leg
@@ -139,3 +143,8 @@ tool.ragmover_ikchains.ik9=Additional slot 5
 tool.ragmover_ikchains.ik10=Additional slot 6
 
 tool.ragmover_ikchains.ikslot=IK slot:
+
+tool.ragmover_ikchains.hip=Hip
+tool.ragmover_ikchains.upperarm=Upperarm
+tool.ragmover_ikchains.knee=Knee
+tool.ragmover_ikchains.elbow=Elbow

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -61,6 +61,8 @@ tool.ragdollmover.scale3=Scale Z
 tool.ragdollmover.resetallbones=Reset All Bones
 
 tool.ragdollmover.scalechildren=Scale children bones
+tool.ragdollmover.snapenable=Enable angle snapping
+tool.ragdollmover.snapamount=Angle snap amount
 
 tool.ragdollmover.resetmenu=Reset
 tool.ragdollmover.resetpos=Position

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -11,11 +11,11 @@ tool.ragdollmover.right_gizmomode=Set offset to coordinate center of the object 
 tool.ragdollmover.reload_gizmomode=Cancel set offset mode
 
 tool.ragdollmover.gizmopanel=Gizmo
-tool.ragdollmover.localpos=Localized position gizmo.
-tool.ragdollmover.localang=Localized angle gizmo.
+tool.ragdollmover.localpos=Localized position gizmo
+tool.ragdollmover.localang=Localized angle gizmo
 tool.ragdollmover.scale=Scale
 tool.ragdollmover.width=Width
-tool.ragdollmover.fulldisc=Fully visible discs.
+tool.ragdollmover.fulldisc=Fully visible discs
 
 tool.ragdollmover.gizmooffsetpanel=Gizmo Offset
 tool.ragdollmover.gizmolocaloffset=Localized offset
@@ -33,12 +33,13 @@ tool.ragdollmover.ik1=Left Leg IK
 tool.ragdollmover.ik2=Right Leg IK
 
 tool.ragdollmover.miscpanel=Misc
-tool.ragdollmover.unfreeze=Unfreeze on release.
-tool.ragdollmover.unfreezetip=Unfreeze bones that were unfrozen before grabbing the ragdoll.
-tool.ragdollmover.disablefilter=Disable entity filter.
+tool.ragdollmover.unfreeze=Unfreeze on release
+tool.ragdollmover.unfreezetip=Unfreeze bones that were unfrozen before grabbing the ragdoll
+tool.ragdollmover.disablefilter=Disable entity filter
 tool.ragdollmover.disablefiltertip=Disable entity filter to select ANY entity. CAUTION - may be buggy
 tool.ragdollmover.drawskeleton=Draw Skeleton
-tool.ragdollmover.updaterate=Tool update rate.
+tool.ragdollmover.updaterate=Tool update rate
+tool.ragdollmover.lockselected=Disable entity selection
 
 tool.ragdollmover.bindrot=Rotate toggle button
 tool.ragdollmover.bindscale=Scale toggle button
@@ -85,6 +86,7 @@ tool.ragdollmover.message3=Can't lock bone to itself, that would be weird!
 tool.ragdollmover.message4=Can't lock entity to nonphysical bones!
 tool.ragdollmover.message5=Entity locking is not allowed here!
 tool.ragdollmover.message6=Entity locked successfully!
+tool.ragdollmover.message20=Can't select any entity until "Disable entity selection" option is disabled!
 
 tool.ragdollmover.putgizmopos=Put Gizmo offset here
 

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -31,6 +31,7 @@ tool.ragdollmover.ik3=Left Hand IK
 tool.ragdollmover.ik4=Right Hand IK
 tool.ragdollmover.ik1=Left Leg IK
 tool.ragdollmover.ik2=Right Leg IK
+tool.ragdollmover.ikall=Select/Deselect All
 
 tool.ragdollmover.miscpanel=Misc
 tool.ragdollmover.unfreeze=Unfreeze on release
@@ -56,6 +57,8 @@ tool.ragdollmover.rot3=Roll
 tool.ragdollmover.scale1=Scale X
 tool.ragdollmover.scale2=Scale Y
 tool.ragdollmover.scale3=Scale Z
+
+tool.ragdollmover.resetallbones=Reset All Bones
 
 tool.ragdollmover.scalechildren=Scale children bones
 
@@ -103,7 +106,9 @@ tool.ragdollmover.lockedbone=Locked Physical Bone
 tool.ragdollmover.nonphysbone=Nonphysical Bone
 tool.ragdollmover.proceduralbone=Procedural Bone
 tool.ragdollmover.parentedbone=Parented Bone
+tool.ragdollmover.bonetolock=Left click on any physical bone on this list to lock it to this bone.
 tool.ragdollmover.lockedbonetobone=Physical Bone locked to another bone
+tool.ragdollmover.entlock=Select a physical bone from bone list to lock this entity to
 
 
 tool.ragmover_ikchains.name=Ragdoll Mover - IK Chains


### PR DESCRIPTION
- Made GetPhysBoneParent function look through 256 possible bones rather than 128, as it seems like SFM models can get in gmod fine and their bone cap is 256 or so (nonphysical, and this function here looks through all nonphysical bones to find one which is connected to physical's parent one)

- Added functionality to lock bones to each other: To do so, right click on a physical bone in the bone tree, select "Lock to this bone" and then left click on any other physical bone to make it locked to the bone you've right clicked on. This will make locked bone move with its "parent", which by default would be only noticeable with IKs, if you lock hand to hand or to a foot. For other usage I'd suggest using ragdoll stretch. Bones can't be locked to any of the parent bones, and they also can't lock nonphysical bones due to their weird rotations.

- Moved "All" panel in nonphysical bone resetting to the top of the list for convenience

- Fixed issue with trying to draw bone children on entities that have no bones

- Fixed issue with weird position/rotation locking behavior on some ragdolls due to TranslateBoneToPhysbone not cooperating

- Fixed issue with locking IK bones to each other, although the fix came down to making the tool calculate IKs twice, there is probably a better way to do that

- Added function to lock constrained (welded, nocollided, that stuff) entities to selected entity's physical bones (only works with physical stuff)

- Added "sv_ragdollmover_allow_constrained_locking" convar which allows or restricts usage of entity locking as I suspected that it could be abused on servers to cause lag

- Added more notifications to notification system thing and improved it a bit

- Added horizontal bar to children entities tree due to it being able to expand horizontally due to showing children of children

- Selecting children entities will now reset bone locks too, to prevent some weird cases from happening

- Optimized the tool by moving Vector, Angle and Color functions with static values outside of looping parts and replaced them with variables, which should save some performance

- Added option to disable entity selection, to prevent selecting other entities by accident

- Added button to select or deselect all IKs in the IK tab

- Added button to reset all nonphysical bones in bone manipulation tab

- Bone and constrained entity locking will now have a bit more feedback, as well as give tips on what to do when you hover over the bone/entity in the list that has triggered lock select mode

- Made horizontal scrollbar adapt to the size of the bonelist, so it would show you correctly bones of models that had its names get out of the panel before

- Fixed an issue related to bone list sorting by physical bones not showing all physical bones if they were also procedural, as I thought that bones can either be procedural or physical 

- Pressing R will now switch to the physical root bone of a ragdoll rather than nonphysical bone with index 0 if it had one for some reason

- Added angle snapping feature that can be setup in "bone manipulation" tab

- IK Chain creator UI overhaul, it also has slots for 6 more limbs

- IK Chain creator now has more notifications, and it will also notify when successfully creating or removing an IK chain

- Moved "stage" reset and IK chain removal button to reload instead of secondary fire

- IK Chain creator now has 3 steps instead of 2, makes life a bit harder as you have to set the knee bone on your own, but should allow for more flexibility with IK rig creation so you can make IKs for limbs with more than 3 bones, and you also can combine several chains for 1 limb (example will be published a bit later)

- Fixed ragdoll mover UI bug with showing wrong icon for physical bones after using bonelocking function

- You can now use 6 additional IK chains through ragdoll mover

- Reworked the way binder buttons behave when resizing tool's menu

- Expanded bone search function to look through 512 bones rather than 256 as it seems like models from SFM can have up to that amount

- IK Chain creator tool will now draw physical skeleton of the ragdoll you're aiming at

- Added save/load functionality for IK Chain creator tool (saved iks will be saved as .txt files in data/rgmik directory, they will be named as the model they were made for, but can be freely renamed by outside means)

- IK Chain creator tool will now show bones that are being used to create current IK chain

- Added "omni" gizmo part to positioning mode which is located in the center of it, which allows to move entities in a plane relative to player's view. Holding down sprint key (shift by default) will make it snap moving gizmo to physical objects and world, while also respecting the gizmo offset setting