### PR TITLE
Prop ragdoll tool

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -239,7 +239,7 @@ local DefIKnames = {
 
 
 --Functions for offset table generation
-local function GetRootBones(parent, physobj, obj1, obj2, RTable, ent, ent2)
+local function GetRootBones(parent, physobj, obj1, obj2, RTable)
 	RTable[physobj] = {}
 	if parent then
 		local pos1,ang1 = obj1:GetPos(),obj1:GetAngles()
@@ -256,7 +256,7 @@ local function GetRootBones(parent, physobj, obj1, obj2, RTable, ent, ent2)
 	RTable[physobj].moving = obj1:IsMoveable()
 end
 
-local function GetBones(bonelock, parent, pb, obj1, obj2, RTable, ent, ent2)
+local function GetBones(bonelock, parent, pb, obj1, obj2, RTable)
 	local pos1,ang1 = obj1:GetPos(),obj1:GetAngles()
 	local pos2,ang2 = obj2:GetPos(),obj2:GetAngles()
 	local pos3,ang3 = WorldToLocal(pos1,ang1,pos2,ang2)
@@ -339,9 +339,8 @@ function GetOffsetTable(tool,ent,rotate, bonelocks, entlocks)
 
 			if pb and parent and not RTable[pb] then
 				local obj1 = thisent:GetPhysicsObjectNum(0)
-				local ent2 = ent.rgmPRidtoent[parent]
-				local obj2 = ent2:GetPhysicsObjectNum(0)
-				GetBones(bonelocks[thisent][pb], parent, pb, obj1, obj2, RTable, ent, ent2)
+				local obj2 = ent.rgmPRidtoent[parent]:GetPhysicsObjectNum(0)
+				GetBones(bonelocks[thisent][pb], parent, pb, obj1, obj2, RTable)
 				RTable[pb].ent = thisent
 				local iktable = IsIKBone(tool,ent,pb)
 				if iktable then

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -456,10 +456,10 @@ local function RecursiveSetParent(ostable, sbone, ent, rlocks, plocks, RTable, b
 		pos = sbone.p
 		ang = sbone.a
 	else
-		if IsValid(rlocks[ent][bone]) then
+		if rlocks[ent] and IsValid(rlocks[ent][bone]) then
 			ang = rlocks[ent][bone]:GetAngles()
 		end
-		if IsValid(plocks[ent][bone]) then
+		if plocks[ent] and IsValid(plocks[ent][bone]) then
 			pos = plocks[ent][bone]:GetPos()
 		end
 	end

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -348,9 +348,9 @@ function GetOffsetTable(tool,ent,rotate, bonelocks, entlocks)
 
 	for k,v in pairs(ent.rgmIKChains) do
 
-		local obj1 = ent:GetPhysicsObjectNum(v.hip)
-		local obj2 = ent:GetPhysicsObjectNum(v.knee)
-		local obj3 = ent:GetPhysicsObjectNum(v.foot)
+		local obj1
+		local obj2
+		local obj3
 
 		if not ent.rgmPRidtoent then
 			obj1 = ent:GetPhysicsObjectNum(v.hip)

--- a/lua/autorun/ragdollmover_meta.lua
+++ b/lua/autorun/ragdollmover_meta.lua
@@ -88,6 +88,7 @@ hook.Add("PlayerSpawn","rgmSpawn",function(pl) --PlayerSpawn is a hook that runs
 		pl.rgm.Rotate = false
 		pl.rgm.Scale = false
 		pl.rgm.GizmoOffset = vector_origin
+		pl.rgm.PropRagdoll = false
 	end
 
 	if not pl.rgmSync or not pl.rgmSyncOne then

--- a/lua/autorun/ragdollmover_meta.lua
+++ b/lua/autorun/ragdollmover_meta.lua
@@ -87,7 +87,7 @@ hook.Add("PlayerSpawn","rgmSpawn",function(pl) --PlayerSpawn is a hook that runs
 		pl.rgmEntLocks = {}
 		pl.rgm.Rotate = false
 		pl.rgm.Scale = false
-		pl.rgm.GizmoOffset = vector_origin
+		pl.rgm.GizmoOffset = Vector(0, 0, 0)
 		pl.rgm.PropRagdoll = false
 	end
 

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -383,6 +383,12 @@ function ENT:Think()
 	self.ArrowZ:SetLocalAngles(ZAng)
 	self.ScaleZ:SetLocalAngles(ZAng)
 
+	if not pl.rgm.Moving then
+		self.ArrowX.GizmoAngle = self.ArrowX:GetAngles()
+		self.ArrowY.GizmoAngle = self.ArrowY:GetAngles()
+		self.ArrowZ.GizmoAngle = self.ArrowZ:GetAngles()
+	end
+
 	self:NextThink(CurTime()+0.001)
 	return true
 end

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -348,7 +348,7 @@ function ENT:Think()
 	end
 
 	if not pl.rgm.Moving then -- Prevent whole thing from rotating when we do localized rotation - needed for proper angle reading
-		if localstate or scale or not pl.rgm.IsPhysBone then -- Non phys bones don't go well with world coordinates. Well, I didn't make them to behave with those
+		if localstate or scale or (not pl.rgm.IsPhysBone and rotate) then -- Non phys bones don't go well with world coordinates. Well, I didn't make them to behave with those
 			self:SetAngles(ang or angle_zero)
 			if not pl.rgm.IsPhysBone then
 				self.DiscP:SetLocalAngles(Angle(0, 90 + ent:GetManipulateBoneAngles(bone).y, 0)) -- Pitch follows Yaw angles

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -10,6 +10,7 @@ local TYPE_ARROW = 1
 local TYPE_ARROWSIDE = 2
 local TYPE_DISC = 3
 
+local VECTOR_ORIGIN = Vector(0,0,0)
 local VECTOR_FRONT = Vector(1,0,0)
 local ANGLE_DISC = Angle(0,90,0)
 local ANGLE_ARROW_OFFSET = Angle(0,90,90)
@@ -309,10 +310,19 @@ function ENT:Think()
 	end
 
 	if not pl.rgm.Moving or not rotate then
+		local entoffset = VECTOR_ORIGIN
+		if ent.rgmPRoffset then
+			entoffset = ent.rgmPRoffset
+		end
+
 		if offsetlocal then 
-			self:SetPos(LocalToWorld(offset, angle_zero, pos, ang))
+			self:SetPos(LocalToWorld(offset + entoffset, angle_zero, pos, ang))
 		else
-			self:SetPos(pos + offset)
+			if ent.rgmPRoffset then
+				entoffset = LocalToWorld(entoffset, angle_zero, pos, ang)
+				entoffset = entoffset - pos
+			end
+			self:SetPos(pos + offset + entoffset)
 		end
 	end
 

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -328,7 +328,11 @@ function ENT:Think()
 		end
 
 		if offsetlocal then 
-			self:SetPos(LocalToWorld(offset + entoffset, angle_zero, pos, ang))
+			if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not (ent:GetClass() == "prop_ragdoll") then
+				self:SetPos(LocalToWorld(offset + entoffset, angle_zero, pos, ent:GetParent():LocalToWorldAngles(ent:GetLocalAngles())))
+			else
+				self:SetPos(LocalToWorld(offset + entoffset, angle_zero, pos, ang))
+			end
 		else
 			if ent.rgmPRoffset then
 				entoffset = LocalToWorld(entoffset, angle_zero, pos, ang)

--- a/lua/entities/rgm_axis_arrow/init.lua
+++ b/lua/entities/rgm_axis_arrow/init.lua
@@ -8,9 +8,15 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 	local localized = self:WorldToLocal(intersect)
 	local axis = self:GetParent()
 	local offset = axis.Owner.rgm.GizmoOffset
+	local entoffset = vector_origin
 	if axis.localizedoffset then
 		offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
 		offset =  offset - axis:GetPos()
+	end
+	if ent.rgmPRoffset then
+		entoffset = LocalToWorld(ent.rgmPRoffset, angle_zero, axis:GetPos(), axis.LocalAngles)
+		entoffset = entoffset - axis:GetPos()
+		offset = offset + entoffset
 	end
 	local pos, ang
 

--- a/lua/entities/rgm_axis_arrow/init.lua
+++ b/lua/entities/rgm_axis_arrow/init.lua
@@ -28,11 +28,33 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		ang = obj:GetAngles()
 		pos = LocalToWorld(Vector(offpos.x,0,0),angle_zero,intersect - offset,selfangle)
 	elseif movetype == 2 then
-		pos = ent:GetManipulateBonePosition(bone)
-		localized = Vector(localized.x - StartGrab.x,0,0)
-		local posadd = NPhysPos[self.axistype] + localized.x
+		local finalpos, boneang
+		local pl = self:GetParent().Owner
+
+		if ent:GetBoneParent(bone) ~= -1 then
+			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
+			boneang = matrix:GetAngles()
+			if not (ent:GetClass() == "prop_physics") then
+				local _ , pang = ent:GetBonePosition(ent:GetBoneParent(bone))
+
+				local _, diff = WorldToLocal(vector_origin, boneang, vector_origin, pang)
+				_, boneang = LocalToWorld(vector_origin, diff, vector_origin, pl.rgm.GizmoParent)
+			end
+		else
+			if IsValid(ent) then
+				boneang = ent:GetAngles()
+			else
+				boneang = angle_zero
+			end
+		end
+
+		intersect = self:LocalToWorld(Vector(localized.x,0,0))
+		localized = LocalToWorld(Vector(offpos.x,0,0),angle_zero,intersect,self:GetAngles())
+		localized = WorldToLocal(localized, angle_zero, self:GetPos(), boneang)
+
+		finalpos = NPhysPos + localized
 		ang = ent:GetManipulateBoneAngles(bone)
-		pos[self.axistype] = posadd
+		pos = finalpos
 	elseif movetype == 0 then
 		localized = Vector(localized.x,0,0)
 		intersect = self:LocalToWorld(localized)

--- a/lua/entities/rgm_axis_arrow/init.lua
+++ b/lua/entities/rgm_axis_arrow/init.lua
@@ -19,13 +19,14 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		offset = offset + entoffset
 	end
 	local pos, ang
+	local selfangle = self.GizmoAngle and self.GizmoAngle or self:GetAngles()
 
 	if movetype == 1 then
 		local obj = ent:GetPhysicsObjectNum(bone)
 		localized = Vector(localized.x,0,0)
 		intersect = self:LocalToWorld(localized)
 		ang = obj:GetAngles()
-		pos = LocalToWorld(Vector(offpos.x,0,0),angle_zero,intersect - offset,self:GetAngles())
+		pos = LocalToWorld(Vector(offpos.x,0,0),angle_zero,intersect - offset,selfangle)
 	elseif movetype == 2 then
 		pos = ent:GetManipulateBonePosition(bone)
 		localized = Vector(localized.x - StartGrab.x,0,0)
@@ -36,7 +37,7 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		localized = Vector(localized.x,0,0)
 		intersect = self:LocalToWorld(localized)
 		ang = ent:GetLocalAngles()
-		pos = LocalToWorld(Vector(offpos.x,0,0),angle_zero,intersect - offset, self:GetAngles())
+		pos = LocalToWorld(Vector(offpos.x,0,0),angle_zero,intersect - offset,selfangle)
 		pos = ent:GetParent():WorldToLocal(pos)
 	end
 	return pos,ang

--- a/lua/entities/rgm_axis_disc/init.lua
+++ b/lua/entities/rgm_axis_disc/init.lua
@@ -37,9 +37,15 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 	if movetype == 1 then
 		local axis = self:GetParent()
 		local offset = axis.Owner.rgm.GizmoOffset
+		local entoffset = vector_origin
 		if axis.localizedoffset and not axis.relativerotate then
 			offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
 			offset = offset - axis:GetPos()
+		end
+		if ent.rgmPRoffset then
+			entoffset = LocalToWorld(ent.rgmPRoffset, angle_zero, axis:GetPos(), axis.LocalAngles)
+			entoffset = entoffset - axis:GetPos()
+			offset = offset + entoffset
 		end
 
 		localized = Vector(localized.y,localized.z,0):Angle()
@@ -102,9 +108,15 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 	elseif movetype == 0 then
 		local axis = self:GetParent()
 		local offset = axis.Owner.rgm.GizmoOffset
+		local entoffset = vector_origin
 		if axis.localizedoffset and not axis.relativerotate then
 			offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
 			offset = offset - axis:GetPos()
+		end
+		if ent.rgmPRoffset then
+			entoffset = LocalToWorld(ent.rgmPRoffset, angle_zero, axis:GetPos(), axis.LocalAngles)
+			entoffset = entoffset - axis:GetPos()
+			offset = offset + entoffset
 		end
 
 		localized = Vector(localized.y,localized.z,0):Angle()

--- a/lua/entities/rgm_axis_disc/init.lua
+++ b/lua/entities/rgm_axis_disc/init.lua
@@ -78,6 +78,21 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		axisangle = axistable[self.axistype]
 
 		local _, boneang = ent:GetBonePosition(bone)
+		if ent:GetClass() == "prop_physics" then
+			local manang = ent:GetManipulateBoneAngles(bone)
+			manang:Normalize()
+
+			_, boneang = LocalToWorld(vector_origin, Angle(0, 0, -manang[3]), vector_origin, boneang)
+			_, boneang = LocalToWorld(vector_origin, Angle(-manang[1], 0, 0), vector_origin, boneang)
+			_, boneang = LocalToWorld(vector_origin, Angle(0, -manang[2], 0), vector_origin, boneang)
+		else
+			if ent:GetBoneParent(bone) ~= -1 then
+				local _ , pang = ent:GetBonePosition(ent:GetBoneParent(bone))
+
+				local _, diff = WorldToLocal(vector_origin, boneang, vector_origin, pang)
+				_, boneang = LocalToWorld(vector_origin, diff, vector_origin, pl.rgm.GizmoParent)
+			end
+		end
 		local startlocal = LocalToWorld(startAngle, startAngle:Angle(), vector_origin, axisangle) -- first we get our vectors into world coordinates, relative to the axis angles
 		localized = LocalToWorld(localized, localized:Angle(), vector_origin, axisangle)
 		localized = WorldToLocal(localized, localized:Angle(), vector_origin, boneang) -- then convert that vector to the angles of the bone

--- a/lua/entities/rgm_axis_disc/init.lua
+++ b/lua/entities/rgm_axis_disc/init.lua
@@ -50,16 +50,28 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 
 		localized = Vector(localized.y,localized.z,0):Angle()
 		startAngle = Vector(startAngle.y, startAngle.z, 0):Angle()
-		local diff = startAngle.y - localized.y
-		local mathfunc = nil
-		if diff >= 0 then
-			mathfunc = math.floor
-		else
-			mathfunc = math.ceil
-		end
 
 		local rotationangle = localized.y
 		if snapamount ~= 0 then
+			local localAng = math.fmod(localized.y, 360)
+			if localAng > 181 then localAng = localAng - 360 end
+			if localAng < -181 then localAng = localAng + 360 end
+
+			local localStart = math.fmod(startAngle.y, 360)
+			if localStart > 181 then localStart = localStart - 360 end
+			if localStart < -181 then localStart = localStart + 360 end
+
+			local diff = math.fmod(localStart - localAng, 360)
+			if diff > 181 then diff = diff - 360 end
+			if diff < -181 then diff = diff + 360 end
+
+			local mathfunc = nil
+			if diff >= 0 then
+				mathfunc = math.floor
+			else
+				mathfunc = math.ceil
+			end
+
 			rotationangle = startAngle.y - (mathfunc(diff / snapamount) * snapamount)
 		end
 
@@ -103,11 +115,16 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 
 		localized = localized:Angle() - startlocal:Angle()
 
-		local mathfunc = math.floor
-		if localized.y < 0 then mathfunc = math.ceil end
 		local rotationangle = localized.y
 		if snapamount ~= 0 then
-			rotationangle = mathfunc(localized.y / snapamount) * snapamount
+			local localAng = math.fmod(localized.y, 360)
+			if localAng > 181 then localAng = localAng - 360 end
+			if localAng < -181 then localAng = localAng + 360 end
+
+			local mathfunc = math.floor
+			if localAng < 0 then mathfunc = math.ceil end
+
+			rotationangle = mathfunc(localAng / snapamount) * snapamount
 		end
 
 		if self.axistype == 4 then
@@ -136,16 +153,28 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 
 		localized = Vector(localized.y,localized.z,0):Angle()
 		startAngle = Vector(startAngle.y, startAngle.z, 0):Angle()
-		local diff = startAngle.y - localized.y
-		local mathfunc = nil
-		if diff >= 0 then
-			mathfunc = math.floor
-		else
-			mathfunc = math.ceil
-		end
 
 		local rotationangle = localized.y
 		if snapamount ~= 0 then
+			local localAng = math.fmod(localized.y, 360)
+			if localAng > 181 then localAng = localAng - 360 end
+			if localAng < -181 then localAng = localAng + 360 end
+
+			local localStart = math.fmod(startAngle.y, 360)
+			if localStart > 181 then localStart = localStart - 360 end
+			if localStart < -181 then localStart = localStart + 360 end
+
+			local diff = math.fmod(localStart - localAng, 360)
+			if diff > 181 then diff = diff - 360 end
+			if diff < -181 then diff = diff + 360 end
+
+			local mathfunc = nil
+			if diff >= 0 then
+				mathfunc = math.floor
+			else
+				mathfunc = math.ceil
+			end
+
 			rotationangle = startAngle.y - (mathfunc(diff / snapamount) * snapamount)
 		end
 

--- a/lua/entities/rgm_axis_scale_side/init.lua
+++ b/lua/entities/rgm_axis_scale_side/init.lua
@@ -10,8 +10,12 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 
 	local localized, startmove, finalpos, boneang
 	if ent:GetBoneParent(bone) ~= -1 then
-		local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
-		boneang = matrix:GetAngles()
+		if pl.rgm.GizmoAng then
+			boneang = pl.rgm.GizmoAng
+		else
+			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
+			boneang = matrix:GetAngles()
+		end
 	else
 		if IsValid(ent) then
 			boneang = ent:GetAngles()

--- a/lua/entities/rgm_axis_side/init.lua
+++ b/lua/entities/rgm_axis_side/init.lua
@@ -25,7 +25,7 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		ang = obj:GetAngles()
 		pos = LocalToWorld(offpos,angle_zero,intersect - offset,self:GetAngles())
 	elseif movetype == 2 then
-		local localized, startmove, finalpos, boneang
+		local localized, finalpos, boneang
 		if ent:GetBoneParent(bone) ~= -1 then
 			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
 			boneang = matrix:GetAngles()

--- a/lua/entities/rgm_axis_side/init.lua
+++ b/lua/entities/rgm_axis_side/init.lua
@@ -29,6 +29,12 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 		if ent:GetBoneParent(bone) ~= -1 then
 			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
 			boneang = matrix:GetAngles()
+			if not (ent:GetClass() == "prop_physics") then
+				local _ , pang = ent:GetBonePosition(ent:GetBoneParent(bone))
+
+				local _, diff = WorldToLocal(vector_origin, boneang, vector_origin, pang)
+				_, boneang = LocalToWorld(vector_origin, diff, vector_origin, pl.rgm.GizmoParent)
+			end
 		else
 			if IsValid(ent) then
 				boneang = ent:GetAngles()

--- a/lua/entities/rgm_axis_side/init.lua
+++ b/lua/entities/rgm_axis_side/init.lua
@@ -7,9 +7,15 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm, mo
 	local intersect = self:GetGrabPos(eyepos,eyeang,ppos,pnorm)
 	local axis = self:GetParent()
 	local offset = axis.Owner.rgm.GizmoOffset
+	local entoffset = vector_origin
 	if axis.localizedoffset then
 		offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
 		offset =  offset - axis:GetPos()
+	end
+	if ent.rgmPRoffset then
+		entoffset = LocalToWorld(ent.rgmPRoffset, angle_zero, axis:GetPos(), axis.LocalAngles)
+		entoffset = entoffset - axis:GetPos()
+		offset = offset + entoffset
 	end
 	local pos, ang
 	local pl = self:GetParent().Owner

--- a/lua/entities/rgm_axis_side_omni/init.lua
+++ b/lua/entities/rgm_axis_side_omni/init.lua
@@ -11,9 +11,15 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm,mov
 
 	local axis = self:GetParent()
 	local offset = axis.Owner.rgm.GizmoOffset
+	local entoffset = vector_origin
 	if axis.localizedoffset then
 		offset = LocalToWorld(offset, angle_zero, axis:GetPos(), axis.LocalAngles)
 		offset =  offset - axis:GetPos()
+	end
+	if ent.rgmPRoffset then
+		entoffset = LocalToWorld(ent.rgmPRoffset, angle_zero, axis:GetPos(), axis.LocalAngles)
+		entoffset = entoffset - axis:GetPos()
+		offset = offset + entoffset
 	end
 	local pos, ang
 	local pl = self:GetParent().Owner

--- a/lua/entities/rgm_axis_side_omni/init.lua
+++ b/lua/entities/rgm_axis_side_omni/init.lua
@@ -33,6 +33,12 @@ function ENT:ProcessMovement(offpos,offang,eyepos,eyeang,ent,bone,ppos,pnorm,mov
 		if ent:GetBoneParent(bone) ~= -1 then
 			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
 			boneang = matrix:GetAngles()
+			if not (ent:GetClass() == "prop_physics") then
+				local _ , pang = ent:GetBonePosition(ent:GetBoneParent(bone))
+
+				local _, diff = WorldToLocal(vector_origin, boneang, vector_origin, pang)
+				_, boneang = LocalToWorld(vector_origin, diff, vector_origin, pl.rgm.GizmoParent)
+			end
 		else
 			if IsValid(ent) then
 				boneang = ent:GetAngles()

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -562,7 +562,7 @@ end)
 
 net.Receive("rgmResetGizmo", function(len, pl)
 	if not pl.rgm then return end
-	pl.rgm.GizmoOffset = Vector(0, 0, 0)
+	pl.rgm.GizmoOffset:Set(vector_origin)
 
 	net.Start("rgmUpdateGizmo")
 	net.WriteVector(pl.rgm.GizmoOffset)
@@ -795,10 +795,9 @@ function TOOL:LeftClick(tr)
 		if SERVER then
 			local pl = self:GetOwner()
 			local axis, ent = pl.rgm.Axis, pl.rgm.Entity
-			local offset = vector_origin
 
 			if not IsValid(axis) or not IsValid(ent) then self:SetOperation(0) return true end
-			offset = tr.HitPos
+			local offset = tr.HitPos
 
 			if ent:GetClass() == "prop_ragdoll" and pl.rgm.IsPhysBone then
 				ent = ent:GetPhysicsObjectNum(pl.rgm.PhysBone)
@@ -1002,7 +1001,7 @@ function TOOL:RightClick(tr)
 			local pl = self:GetOwner()
 			local axis = pl.rgm.Axis
 			local ent, rgment = tr.Entity, pl.rgm.Entity
-			local offset = vector_origin
+			local offset
 
 			if not IsValid(axis) or not IsValid(rgment) then self:SetOperation(0) return true end
 

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -115,7 +115,7 @@ local function rgmGetConstrainedEntities(parent)
 	local count = 1
 
 	for _, ent in pairs(conents) do
-		if not IsValid(ent) or ent:IsWorld() or ent:IsConstraint() or not util.IsValidModel(ent:GetModel()) then continue end
+		if not IsValid(ent) or ent:IsWorld() or ent:IsConstraint() or not util.IsValidModel(ent:GetModel()) or IsValid(ent:GetParent()) then continue end
 		if ent:GetPhysicsObjectCount() > 0 then
 			children[count] = ent
 			count = count + 1

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1175,10 +1175,19 @@ if SERVER then
 
 		local tracepos = nil
 		if pl:KeyDown(IN_SPEED) then
+			local ignore = { pl }
+			if ent.rgmPRidtoent then
+				for id, e in pairs(ent.rgmPRidtoent) do
+					table.insert(ignore, e)
+				end
+			else
+				ignore[2] = ent
+			end
+
 			local tr = util.TraceLine({
 				start = pl:EyePos(),
 				endpos = pl:EyePos() + pl:GetAimVector()*4096,
-				filter = {ent, pl}
+				filter = ignore
 			})
 			tracepos = tr.HitPos
 		end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1245,18 +1245,18 @@ if SERVER then
 						local boneid = not pl.rgm.PropRagdoll and i or 0
 
 						local obj = ent:GetPhysicsObjectNum(boneid)
-						local poslen = postable[i].pos:Length()
-						local anglen = Vector(postable[i].ang.p,postable[i].ang.y,postable[i].ang.r):Length()
+	--					local poslen = postable[i].pos:Length()
+	--					local anglen = Vector(postable[i].ang.p,postable[i].ang.y,postable[i].ang.r):Length()
 
 						--Temporary solution for INF and NaN decimals crashing the game (Even rounding doesnt fix it)
-						if poslen > 2 and anglen > 2 then
+	--					if poslen > 2 and anglen > 2 then
 							obj:EnableMotion(true)
 							obj:Wake()
 							obj:SetPos(postable[i].pos)
 							obj:SetAngles(postable[i].ang)
 							obj:EnableMotion(false)
 							obj:Wake()
-						end
+	--					end
 					end
 
 					if postable[i] and postable[i].locked and ConstrainedAllowed:GetBool() then
@@ -1264,18 +1264,18 @@ if SERVER then
 							for j=0,lockent:GetPhysicsObjectCount()-1 do
 								if bones[j] then
 									local obj = lockent:GetPhysicsObjectNum(j)
-									local poslen = bones[j].pos:Length()
-									local anglen = Vector(bones[j].ang.p,bones[j].ang.y,bones[j].ang.r):Length()
+	--								local poslen = bones[j].pos:Length()
+	--								local anglen = Vector(bones[j].ang.p,bones[j].ang.y,bones[j].ang.r):Length()
 
 									--Temporary solution for INF and NaN decimals crashing the game (Even rounding doesnt fix it)
-									if poslen > 2 and anglen > 2 then
+	--								if poslen > 2 and anglen > 2 then
 										obj:EnableMotion(true)
 										obj:Wake()
 										obj:SetPos(bones[j].pos)
 										obj:SetAngles(bones[j].ang)
 										obj:EnableMotion(false)
 										obj:Wake()
-									end
+	--								end
 
 								end
 							end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1076,6 +1076,7 @@ function TOOL:Think()
 			else
 				pl.rgm.GizmoParent = nil
 			end
+
 			pl.rgm.GizmoPos = pos
 			pl.rgm.GizmoAng = ang
 			pl:rgmSyncClient("GizmoPos")
@@ -2810,7 +2811,7 @@ net.Receive("rgmSelectBoneResponse", function(len)
 	end
 
 	if nodes then
-		if ent:GetClass() == "prop_ragdoll" and isphys and nodes[ent] and nodes[ent][boneid] then
+		if isphys and nodes[ent] and nodes[ent][boneid] then
 			SetVisiblePhysControls(true)
 		else
 			SetVisiblePhysControls(false)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -106,6 +106,11 @@ local function rgmGetConstrainedEntities(parent)
 
 	conents = constraint.GetAllConstrainedEntities(parent)
 	conents[parent] = nil
+	if parent.rgmPRidtoent then
+		for k, ent in pairs(parent.rgmPRidtoent) do
+			conents[ent] = nil
+		end
+	end
 
 	local count = 1
 
@@ -169,64 +174,118 @@ util.AddNetworkString("rgmNotification")
 ConstrainedAllowed = CreateConVar("sv_ragdollmover_allow_constrained_locking", 1, FCVAR_ARCHIVE + FCVAR_NOTIFY, "Allow usage of locking constrained entities to Ragdoll Mover's selected entity (Can be abused by attempting to move a lot of entities)", 0, 1)
 
 net.Receive("rgmAskForPhysbones", function(len, pl)
-	local ent = net.ReadEntity()
-	if not IsValid(ent) then return end
+	local entcount = net.ReadUInt(13)
+	local ents = {}
 
-	local count = ent:GetPhysicsObjectCount() - 1
-	if count ~= -1 then
-		net.Start("rgmAskForPhysbonesResponse")
-			net.WriteUInt(count, 8)
-			for i = 0, count do
-				local bone = ent:TranslatePhysBoneToBone(i)
-				if bone == -1 then bone = 0 end
-				net.WriteUInt(bone, 8)
-				net.WriteBool(pl.rgmPosLocks[i] ~= nil)
-				net.WriteBool(pl.rgmAngLocks[i] ~= nil)
-				net.WriteBool(pl.rgmBoneLocks[i] ~= nil)
-			end
-		net.Send(pl)
+	for i = 1, entcount do
+		ents[i] = net.ReadEntity()
 	end
+
+	if not next(ents) then return end
+	local sendents = {}
+
+	for i, ent in ipairs(ents) do
+		if not IsValid(ent) then continue end
+		local count = ent:GetPhysicsObjectCount() - 1
+		if count ~= -1 then
+			table.insert(sendents, ent)
+		end
+	end
+
+	net.Start("rgmAskForPhysbonesResponse")
+	net.WriteUInt(#sendents, 13)
+	for _, ent in ipairs(sendents) do
+		net.WriteEntity(ent)
+
+		local count = ent:GetPhysicsObjectCount() - 1
+		net.WriteUInt(count, 8)
+		for i = 0, count do
+			local bone = ent:TranslatePhysBoneToBone(i)
+			if bone == -1 then bone = 0 end
+			local poslock = pl.rgmPosLocks[ent] and pl.rgmPosLocks[ent][i] or nil
+			local anglock = pl.rgmAngLocks[ent] and pl.rgmAngLocks[ent][i] or nil
+			local bonelock = pl.rgmBoneLocks[ent] and pl.rgmBoneLocks[ent][i] or nil
+
+			net.WriteUInt(bone, 8)
+			net.WriteBool(poslock ~= nil)
+			net.WriteBool(anglock ~= nil)
+			net.WriteBool(bonelock ~= nil)
+		end
+	end
+	net.Send(pl)
 end)
 
 net.Receive("rgmAskForNodeUpdatePhysics", function(len, pl)
 	local isphys = net.ReadBool()
-	local ent = net.ReadEntity()
+	local entcount = net.ReadUInt(13)
+	local reents, ents = {}, {}
 
-	if not IsValid(ent) then return end
+	for i = 1, entcount do
+		reents[i] = net.ReadEntity()
+	end
 
-	local count = ent:GetPhysicsObjectCount() - 1
-	if count ~= -1 then
-		net.Start("rgmAskForNodeUpdatePhysicsResponse")
-			net.WriteBool(isphys)
+	local validcount = 0
+	for i, ent in ipairs(reents) do
+		if not IsValid(ent) then continue end
+		validcount = validcount + 1
+		ents[validcount] = ent
+	end
+
+	if not next(ents) then return end
+
+	net.Start("rgmAskForNodeUpdatePhysicsResponse")
+		net.WriteBool(isphys)
+		net.WriteUInt(validcount, 13)
+		for i, ent in ipairs(ents) do
 			net.WriteEntity(ent)
 
+			local count = ent:GetPhysicsObjectCount()
 			net.WriteUInt(count, 8)
-			for i = 0, count do
-				local bone = ent:TranslatePhysBoneToBone(i)
-				if bone == -1 then bone = 0 end
-				net.WriteUInt(bone, 8)
+			if count ~= 0 then
+				for i = 0, count - 1 do
+					local bone = ent:TranslatePhysBoneToBone(i)
+					if bone == -1 then bone = 0 end
+					net.WriteUInt(bone, 8)
+				end
 			end
-		net.Send(pl)
-	end
+
+		end
+	net.Send(pl)
 end)
 
 net.Receive("rgmAskForParented", function(len, pl)
-	local ent = net.ReadEntity()
-	if not IsValid(ent) or not IsValid(ent:GetParent()) then return end
+	local entcount = net.ReadUInt(13)
+	local ents = {}
+
+	for i = 1, entcount do
+		ents[i] = net.ReadEntity()
+	end
 
 	local parented = {}
+	local pcount = 0
 
-	for i = 0, ent:GetBoneCount() - 1 do
-		if ent:GetParent():LookupBone(ent:GetBoneName(i)) then
-			table.insert(parented, i)
+	for _, ent in ipairs(ents) do
+		if not IsValid(ent) or not IsValid(ent:GetParent()) then continue end
+
+		parented[ent] = {}
+		pcount = pcount + 1
+
+		for i = 0, ent:GetBoneCount() - 1 do
+			if ent:GetParent():LookupBone(ent:GetBoneName(i)) then
+				table.insert(parented[ent], i)
+			end
 		end
 	end
 
 	if next(parented) then
 		net.Start("rgmAskForParentedResponse")
-			net.WriteUInt(#parented, 32)
-			for k, id in ipairs(parented) do
-				net.WriteUInt(id, 32)
+			net.WriteUInt(pcount, 13)
+			for ent, bones in pairs(parented) do
+				net.WriteEntity(ent)
+				net.WriteUInt(#bones, 10)
+				for k, id in ipairs(bones) do
+					net.WriteUInt(id, 10)
+				end
 			end
 		net.Send(pl)
 	end
@@ -234,46 +293,56 @@ end)
 
 net.Receive("rgmSelectBone", function(len, pl)
 	local ent = net.ReadEntity()
-	local bone = net.ReadUInt(32)
+	local bone = net.ReadUInt(10)
 
 	pl.rgm.BoneToResetTo = (ent:GetClass() == "prop_ragdoll") and ent:TranslatePhysBoneToBone(0) or 0
+	pl.rgm.Entity = ent
 	RGMGetBone(pl, ent, bone)
 	pl:rgmSync()
 
 	net.Start("rgmSelectBoneResponse")
 		net.WriteBool(pl.rgm.IsPhysBone)
 		net.WriteEntity(ent)
-		net.WriteUInt(pl.rgm.Bone, 32)
+		net.WriteUInt(pl.rgm.Bone, 10)
 	net.Send(pl)
 end)
 
 net.Receive("rgmLockBone", function(len, pl)
+	local ent = net.ReadEntity()
 	local mode = net.ReadUInt(2)
-	local ent = pl.rgm.Entity
-	local bone = net.ReadUInt(8)
+	local bone = net.ReadUInt(10)
+	local physbone = bone
+	local boneid
 
-	if not IsValid(ent) or ent:TranslateBoneToPhysBone(bone) == -1 then return end
-	if ent:GetClass() ~= "prop_ragdoll" then return end
-	bone = rgm.BoneToPhysBone(ent,bone)
+	if not IsValid(ent) or ent:TranslateBoneToPhysBone(physbone) == -1 then return end
+	if ent:GetClass() ~= "prop_ragdoll" and not ent.rgmPRenttoid then return end
+
+	if ent:GetClass() == "prop_ragdoll" then
+		physbone = rgm.BoneToPhysBone(ent,bone)
+		boneid = physbone
+	else
+		boneid = ent.rgmPRenttoid[ent]
+	end
 
 	if mode == 1 then
-		if not pl.rgmPosLocks[bone] then
-			pl.rgmPosLocks[bone] = ent:GetPhysicsObjectNum(bone)
+		if not pl.rgmPosLocks[ent][boneid] then
+			pl.rgmPosLocks[ent][boneid] = ent:GetPhysicsObjectNum(physbone)
 		else
-			pl.rgmPosLocks[bone] = nil
+			pl.rgmPosLocks[ent][boneid] = nil
 		end
 	elseif mode == 2 then
-		if not pl.rgmAngLocks[bone] then
-			pl.rgmAngLocks[bone] = ent:GetPhysicsObjectNum(bone)
+		if not pl.rgmAngLocks[ent][boneid] then
+			pl.rgmAngLocks[ent][boneid] = ent:GetPhysicsObjectNum(physbone)
 		else
-			pl.rgmAngLocks[bone] = nil
+			pl.rgmAngLocks[ent][boneid] = nil
 		end
 	end
 
-	local poslock, anglock = IsValid(pl.rgmPosLocks[bone]), IsValid(pl.rgmAngLocks[bone])
+	local poslock, anglock = IsValid(pl.rgmPosLocks[ent][boneid]), IsValid(pl.rgmAngLocks[ent][boneid])
 
 	net.Start("rgmLockBoneResponse")
-		net.WriteUInt(ent:TranslatePhysBoneToBone(bone), 32)
+		net.WriteEntity(ent)
+		net.WriteUInt(bone, 10)
 		net.WriteBool(poslock)
 		net.WriteBool(anglock)
 	net.Send(pl)
@@ -292,14 +361,34 @@ local function RecursiveFindIfParent(ent, lockbone, locktobone)
 	end
 end
 
+local function RecursiveFindIfParentPropRagdoll(parentent, childent)
+	local parent = childent.rgmPRparent
+	if not parent then return false end
+
+	parent = childent.rgmPRidtoent[parent]
+	if parent == parentent then
+		return true
+	else
+		return RecursiveFindIfParentPropRagdoll(parentent, parent)
+	end
+end
+
 net.Receive("rgmLockToBone", function(len, pl)
-	local lockedbone = net.ReadUInt(8)
-	local lockorigin = net.ReadUInt(8)
-	local ent = pl.rgm.Entity
+	local lockent = net.ReadEntity()
+	local lockedbone = net.ReadUInt(10)
+	local originent = net.ReadEntity()
+	local lockorigin = net.ReadUInt(10)
 
-	if not IsValid(ent) or not (ent:GetClass() == "prop_ragdoll") then return end
+	if not IsValid(lockent) or not IsValid(originent) or not ((lockent:GetClass() == "prop_ragdoll") or (lockent:GetClass() == "prop_physics")) or not ((originent:GetClass() == "prop_ragdoll") or (originent:GetClass() == "prop_physics")) then return end
+	if lockent.rgmPRenttoid then
+		lockedbone = lockent.rgmPRenttoid[lockent]
+	end
+	if originent.rgmPRenttoid then
+		lockorigin = originent.rgmPRenttoid[originent]
+	end
 
-	local physcheck = not rgm.BoneToPhysBone(ent, lockedbone) or not rgm.BoneToPhysBone(ent, lockorigin)
+
+	local physcheck = not lockent.rgmPRenttoid and (not rgm.BoneToPhysBone(lockent, lockedbone) or not rgm.BoneToPhysBone(originent, lockorigin))
 	local samecheck = lockedbone == lockorigin
 
 	if physcheck or samecheck then
@@ -311,38 +400,61 @@ net.Receive("rgmLockToBone", function(len, pl)
 		return
 	end
 
-	if not RecursiveFindIfParent(ent, lockedbone, lockorigin) then
-		local bone = rgm.BoneToPhysBone(ent,lockedbone)
-		lockorigin = rgm.BoneToPhysBone(ent,lockorigin)
+	if lockent == originent then
+		if not RecursiveFindIfParent(lockent, lockedbone, lockorigin) then
+			local bone = rgm.BoneToPhysBone(lockent,lockedbone)
+			lockorigin = rgm.BoneToPhysBone(lockent,lockorigin)
 
-		pl.rgmBoneLocks[bone] = lockorigin
-		pl.rgmPosLocks[bone] = nil
-		pl.rgmAngLocks[bone] = nil
+			pl.rgmBoneLocks[lockent][bone] = { id = lockorigin, ent = lockent }
+			pl.rgmPosLocks[lockent][bone] = nil
+			pl.rgmAngLocks[lockent][bone] = nil
 
-		net.Start("rgmLockToBoneResponse")
-			net.WriteUInt(lockedbone, 8)
-		net.Send(pl)
+			net.Start("rgmLockToBoneResponse")
+				net.WriteEntity(lockent)
+				net.WriteUInt(lockedbone, 10)
+			net.Send(pl)
+		else
+			net.Start("rgmNotification")
+				net.WriteUInt(RGM_NOTIFY.BONELOCK_FAILED.id, 5)
+			net.Send(pl)
+		end
 	else
-		net.Start("rgmNotification")
-			net.WriteUInt(RGM_NOTIFY.BONELOCK_FAILED.id, 5)
-		net.Send(pl)
+		if not RecursiveFindIfParentPropRagdoll(lockent, originent) then
+			pl.rgmBoneLocks[lockent][lockedbone] = { id = lockorigin, ent = originent }
+			pl.rgmPosLocks[lockent][lockedbone] = nil
+			pl.rgmAngLocks[lockent][lockedbone] = nil
+
+			net.Start("rgmLockToBoneResponse")
+				net.WriteEntity(lockent)
+				net.WriteUInt(0, 10)
+			net.Send(pl)
+		else
+			net.Start("rgmNotification")
+				net.WriteUInt(RGM_NOTIFY.BONELOCK_FAILED.id, 5)
+			net.Send(pl)
+		end
 	end
 end)
 
 net.Receive("rgmUnlockToBone", function(len, pl)
-	local unlockbone = net.ReadUInt(8)
-	local ent = pl.rgm.Entity
+	local ent = net.ReadEntity()
+	local unlockbone = net.ReadUInt(10)
 	local bone = rgm.BoneToPhysBone(ent,unlockbone)
 
-	pl.rgmBoneLocks[bone] = nil
+	if ent.rgmPRenttoid then
+		bone = ent.rgmPRenttoid[ent]
+	end
+
+	pl.rgmBoneLocks[ent][bone] = nil
 
 	net.Start("rgmUnlockToBoneResponse")
-		net.WriteUInt(unlockbone, 8)
+		net.WriteEntity(ent)
+		net.WriteUInt(unlockbone, 10)
 	net.Send(pl)
 end)
 
 net.Receive("rgmLockConstrained", function(len, pl)
-	local ent = pl.rgm.Entity
+	local ent = net.ReadEntity()
 	local lockent = net.ReadEntity()
 	local physbone = 0
 
@@ -358,17 +470,22 @@ net.Receive("rgmLockConstrained", function(len, pl)
 
 	if net.ReadBool() then
 		local boneid = net.ReadUInt(8)
-		if not rgm.BoneToPhysBone(ent, boneid) then
-			net.Start("rgmNotification")
-				net.WriteUInt(RGM_NOTIFY.ENTLOCK_FAILED_NONPHYS.id, 5)
-			net.Send(pl)
-			return
-		end
 
-		physbone = rgm.BoneToPhysBone(ent, boneid)
+		if not ent.rgmPRenttoid then
+			if not rgm.BoneToPhysBone(ent, boneid) then
+				net.Start("rgmNotification")
+					net.WriteUInt(RGM_NOTIFY.ENTLOCK_FAILED_NONPHYS.id, 5)
+				net.Send(pl)
+				return
+			end
+
+			physbone = rgm.BoneToPhysBone(ent, boneid)
+		else
+			physbone = ent.rgmPRenttoid[ent]
+		end
 	end
 
-	pl.rgmEntLocks[lockent] = physbone
+	pl.rgmEntLocks[lockent] = {id = physbone, ent = ent}
 
 	net.Start("rgmLockConstrainedResponse")
 		net.WriteBool(true)
@@ -377,10 +494,9 @@ net.Receive("rgmLockConstrained", function(len, pl)
 end)
 
 net.Receive("rgmUnlockConstrained", function(len, pl)
-	local ent = pl.rgm.Entity
 	local lockent = net.ReadEntity()
 
-	if not IsValid(ent) or not IsValid(lockent) then return end
+	if not IsValid(lockent) then return end
 
 	pl.rgmEntLocks[lockent] = nil
 
@@ -407,6 +523,19 @@ net.Receive("rgmSelectEntity", function(len, pl)
 	pl.rgmPosLocks = {}
 	pl.rgmAngLocks = {}
 	pl.rgmBoneLocks = {}
+
+	if ent.rgmPRidtoent then
+		for id, e in pairs(ent.rgmPRidtoent) do
+			pl.rgmPosLocks[e] = {}
+			pl.rgmAngLocks[e] = {}
+			pl.rgmBoneLocks[e] = {}
+		end
+	else
+		pl.rgmPosLocks[ent] = {}
+		pl.rgmAngLocks[ent] = {}
+		pl.rgmBoneLocks[ent] = {}
+	end
+
 	pl.rgmEntLocks = {}
 
 	if not ent.rgmbonecached then -- also taken from locrotscale. some hacky way to cache the bones?
@@ -416,15 +545,15 @@ net.Receive("rgmSelectEntity", function(len, pl)
 		ent.rgmbonecached = true
 	end
 
-	RGMGetBone(pl, pl.rgm.Entity, 0)
+	RGMGetBone(pl, ent, 0)
 	pl:rgmSync()
 
-	local physchildren = rgmGetConstrainedEntities(pl.rgm.Entity)
+	local physchildren = rgmGetConstrainedEntities(ent)
 
 	net.Start("rgmUpdateEntInfo")
 		net.WriteEntity(ent)
 
-		net.WriteUInt(#physchildren, 32)
+		net.WriteUInt(#physchildren, 13)
 		for _, ent in ipairs(physchildren) do
 			net.WriteEntity(ent)
 		end
@@ -479,11 +608,13 @@ local function RecursiveBoneFunc(bone, ent, func, param)
 end
 
 net.Receive("rgmResetAll", function(len, pl)
-	if not pl.rgm or not IsValid(pl.rgm.Entity) then net.ReadUInt(8) net.ReadBool() return end
-	local ent = pl.rgm.Entity
-	local bone = net.ReadUInt(8)
+	local ent = net.ReadEntity()
+	local bone = net.ReadUInt(10)
+	local children = net.ReadBool()
 
-	if net.ReadBool() then
+	if not IsValid(ent) then return end
+
+	if children then
 		RecursiveBoneFunc(bone, ent, function(bon)
 			ent:ManipulateBonePosition(bon, vector_origin)
 			ent:ManipulateBoneAngles(bon, angle_zero)
@@ -500,13 +631,16 @@ net.Receive("rgmResetAll", function(len, pl)
 end)
 
 net.Receive("rgmResetPos", function(len, pl)
-	if not pl.rgm or not IsValid(pl.rgm.Entity) then net.ReadBool() net.ReadUInt(8) return end
-	local ent = pl.rgm.Entity
+	local ent = net.ReadEntity()
+	local children = net.ReadBool()
+	local bone = net.ReadUInt(10)
 
-	if net.ReadBool() then
-		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBonePosition(bone, param) end, vector_origin)
+	if not IsValid(ent) then return end
+
+	if children then
+		RecursiveBoneFunc(bone, ent, function(bone, param) ent:ManipulateBonePosition(bone, param) end, vector_origin)
 	else
-		ent:ManipulateBonePosition(net.ReadUInt(8), vector_origin)
+		ent:ManipulateBonePosition(bone, vector_origin)
 	end
 
 	net.Start("rgmUpdateSliders")
@@ -514,13 +648,14 @@ net.Receive("rgmResetPos", function(len, pl)
 end)
 
 net.Receive("rgmResetAng", function(len, pl)
-	if not pl.rgm or not IsValid(pl.rgm.Entity) then net.ReadBool() net.ReadUInt(8) return end
-	local ent = pl.rgm.Entity
+	local ent = net.ReadEntity()
+	local children = net.ReadBool()
+	local bone = net.ReadUInt(10)
 
-	if net.ReadBool() then
-		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBoneAngles(bone, param) end, angle_zero)
+	if children then
+		RecursiveBoneFunc(bone, ent, function(bone, param) ent:ManipulateBoneAngles(bone, param) end, angle_zero)
 	else
-		ent:ManipulateBoneAngles(net.ReadUInt(8), angle_zero)
+		ent:ManipulateBoneAngles(bone, angle_zero)
 	end
 
 	net.Start("rgmUpdateSliders")
@@ -528,13 +663,14 @@ net.Receive("rgmResetAng", function(len, pl)
 end)
 
 net.Receive("rgmResetScale", function(len, pl)
-	if not pl.rgm or not IsValid(pl.rgm.Entity) then net.ReadBool() net.ReadUInt(8) return end
-	local ent = pl.rgm.Entity
+	local ent = net.ReadEntity()
+	local children = net.ReadBool()
+	local bone = net.ReadUInt(10)
 
-	if net.ReadBool() then
-		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBoneScale(bone, param) end, Vector(1, 1, 1))
+	if children then
+		RecursiveBoneFunc(bone, ent, function(bone, param) ent:ManipulateBoneScale(bone, param) end, Vector(1, 1, 1))
 	else
-		ent:ManipulateBoneScale(net.ReadUInt(8), Vector(1, 1, 1))
+		ent:ManipulateBoneScale(bone, Vector(1, 1, 1))
 	end
 
 	net.Start("rgmUpdateSliders")
@@ -542,13 +678,14 @@ net.Receive("rgmResetScale", function(len, pl)
 end)
 
 net.Receive("rgmScaleZero", function(len, pl)
-	if not pl.rgm or not IsValid(pl.rgm.Entity) then net.ReadBool() net.ReadUInt(8) return end
-	local ent = pl.rgm.Entity
+	local ent = net.ReadEntity()
+	local children = net.ReadBool()
+	local bone = net.ReadUInt(10)
 
-	if net.ReadBool() then
-		RecursiveBoneFunc(net.ReadUInt(8), ent, function(bone, param) ent:ManipulateBoneScale(bone, param) end, vector_origin)
+	if children then
+		RecursiveBoneFunc(bone, ent, function(bone, param) ent:ManipulateBoneScale(bone, param) end, vector_origin)
 	else
-		ent:ManipulateBoneScale(net.ReadUInt(8), vector_origin)
+		ent:ManipulateBoneScale(bone, vector_origin)
 	end
 
 	net.Start("rgmUpdateSliders")
@@ -630,7 +767,7 @@ concommand.Add("ragdollmover_resetroot", function(pl)
 	net.Start("rgmSelectBoneResponse")
 		net.WriteBool(pl.rgm.IsPhysBone)
 		net.WriteEntity(pl.rgm.Entity)
-		net.WriteUInt(pl.rgm.Bone, 32)
+		net.WriteUInt(pl.rgm.Bone, 10)
 	net.Send(pl)
 end)
 
@@ -755,8 +892,7 @@ function TOOL:LeftClick(tr)
 
 	elseif IsValid(tr.Entity) and EntityFilter(tr.Entity) then
 
-		local entity
-		entity = tr.Entity
+		local entity = tr.Entity
 
 		if entity ~= pl.rgm.Entity and self:GetClientNumber("lockselected") ~= 0 then
 			net.Start("rgmNotification")
@@ -765,8 +901,7 @@ function TOOL:LeftClick(tr)
 			return false
 		end
 
-		pl.rgm.Entity = tr.Entity
-		pl.rgm.ParentEntity = tr.Entity
+		pl.rgm.Entity = entity
 
 		if not entity.rgmbonecached then -- also taken from locrotscale. some hacky way to cache the bones?
 			pl.rgmSwep = self.SWEP
@@ -779,18 +914,50 @@ function TOOL:LeftClick(tr)
 		RGMGetBone(pl, entity, entity:TranslatePhysBoneToBone(tr.PhysicsBone))
 		pl.rgm.BoneToResetTo = (entity:GetClass() == "prop_ragdoll") and entity:TranslatePhysBoneToBone(0) or 0 -- used for quickswitching to root bone and back
 
-		if ent ~= pl.rgm.ParentEntity then
-			local children = rgmFindEntityChildren(pl.rgm.ParentEntity)
-			local physchildren = rgmGetConstrainedEntities(pl.rgm.ParentEntity)
+		if ent ~= entity and (not entity.rgmPRenttoid or not entity.rgmPRenttoid[ent]) then
+			local children = rgmFindEntityChildren(entity)
+			local physchildren = rgmGetConstrainedEntities(entity)
+			pl.rgm.PropRagdoll = entity.rgmPRidtoent and true or false
 
 			net.Start("rgmUpdateLists")
-				net.WriteEntity(pl.rgm.Entity)
-				net.WriteUInt(#children, 32)
+				net.WriteBool(pl.rgm.PropRagdoll)
+				if pl.rgm.PropRagdoll then
+					local rgment = pl.rgm.Entity
+					local count = #rgment.rgmPRidtoent + 1
+
+					net.WriteUInt(count, 13) -- technically entity limit is 4096, but doubtful single prop ragdoll would reach that, but still...
+
+					for id, ent in pairs(rgment.rgmPRidtoent) do
+						net.WriteEntity(ent)
+						net.WriteUInt(id, 13)
+
+						net.WriteBool(ent.rgmPRparent and true or false)
+						if ent.rgmPRparent then
+							net.WriteUInt(ent.rgmPRparent, 13)
+						end
+
+						if ent == entity then
+							net.WriteUInt(0, 13)
+							continue
+						end
+
+						local entchildren = rgmFindEntityChildren(ent)
+						net.WriteUInt(#entchildren, 13)
+
+						for k, v in ipairs(entchildren) do
+							net.WriteEntity(v)
+						end
+					end
+				end
+
+				net.WriteEntity(entity)
+
+				net.WriteUInt(#children, 13)
 				for k, v in ipairs(children) do
 					net.WriteEntity(v)
 				end
 
-				net.WriteUInt(#physchildren, 32)
+				net.WriteUInt(#physchildren, 13)
 				for _, ent in ipairs(physchildren) do
 					net.WriteEntity(ent)
 				end
@@ -799,6 +966,19 @@ function TOOL:LeftClick(tr)
 			pl.rgmPosLocks = {}
 			pl.rgmAngLocks = {}
 			pl.rgmBoneLocks = {}
+
+			if entity.rgmPRidtoent then
+				for id, ent in pairs(entity.rgmPRidtoent) do
+					pl.rgmPosLocks[ent] = {}
+					pl.rgmAngLocks[ent] = {}
+					pl.rgmBoneLocks[ent] = {}
+				end
+			else
+				pl.rgmPosLocks[entity] = {}
+				pl.rgmAngLocks[entity] = {}
+				pl.rgmBoneLocks[entity] = {}
+			end
+
 			pl.rgmEntLocks = {}
 		end
 
@@ -807,7 +987,7 @@ function TOOL:LeftClick(tr)
 		net.Start("rgmSelectBoneResponse")
 			net.WriteBool(pl.rgm.IsPhysBone)
 			net.WriteEntity(pl.rgm.Entity)
-			net.WriteUInt(pl.rgm.Bone, 32)
+			net.WriteUInt(pl.rgm.Bone, 10)
 		net.Send(pl)
 	end
 
@@ -1011,13 +1191,19 @@ if SERVER then
 				local pos, ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,0,snapamount,pl.rgm.StartAngle,nil,nil,nil,tracepos)
 				ent:SetLocalPos(pos)
 				ent:SetLocalAngles(ang)
-			elseif pl.rgm.IsPhysBone then -- moving physbones
 
+			elseif pl.rgm.IsPhysBone then -- moving physbones
 				local isik,iknum = rgm.IsIKBone(self,ent,bone)
 
 				local pos,ang = apart:ProcessMovement(pl.rgmOffsetPos,pl.rgmOffsetAng,eyepos,eyeang,ent,bone,pl.rgmISPos,pl.rgmISDir,1,snapamount,pl.rgm.StartAngle,nil,nil,nil,tracepos)
 
-				local obj = ent:GetPhysicsObjectNum(bone)
+				local physcount = ent:GetPhysicsObjectCount()-1
+				if pl.rgm.PropRagdoll then
+					physcount = #ent.rgmPRidtoent
+					bone = ent.rgmPRenttoid[ent]
+				end
+
+				local obj = ent:GetPhysicsObjectNum(pl.rgm.PropRagdoll and 0 or bone)
 				if not isik or iknum == 3 or (rotate and (iknum == 1 or iknum == 2)) then
 					obj:EnableMotion(true)
 					obj:Wake()
@@ -1027,10 +1213,19 @@ if SERVER then
 					obj:Wake()
 				elseif iknum == 2 then
 					for k,v in pairs(ent.rgmIKChains) do
-						if v.knee == bone then
+						if v.knee == bone or (ent.rgmPRidtoent and ent.rgmPRidtoent[v.knee] == ent) then
 							local intersect = apart:GetGrabPos(eyepos,eyeang)
-							local obj1 = ent:GetPhysicsObjectNum(v.hip)
-							local obj2 = ent:GetPhysicsObjectNum(v.foot)
+							local obj1
+							local obj2
+
+							if not pl.rgm.PropRagdoll then
+								obj1 = ent:GetPhysicsObjectNum(v.hip)
+								obj2 = ent:GetPhysicsObjectNum(v.foot)
+							else
+								obj1 = ent.rgmPRidtoent[v.hip]:GetPhysicsObjectNum(0)
+								obj2 = ent.rgmPRidtoent[v.foot]:GetPhysicsObjectNum(0)
+							end
+
 							local kd = (intersect-(obj2:GetPos()+(obj1:GetPos()-obj2:GetPos())))
 							kd:Normalize()
 							ent.rgmIKChains[k].ikkneedir = kd*1
@@ -1038,16 +1233,18 @@ if SERVER then
 					end
 				end
 
-
 				local postable = rgm.SetOffsets(self,ent,pl.rgmOffsetTable,{b = bone,p = obj:GetPos(),a = obj:GetAngles()}, pl.rgmAngLocks, pl.rgmPosLocks)
 
-				local sbik,sbiknum = rgm.IsIKBone(self,ent,bone)
-				if not sbik or sbiknum ~= 2 then
+				if not isik or iknum ~= 2 then
 					postable[bone].dontset = true
 				end
-				for i=0,ent:GetPhysicsObjectCount()-1 do
+
+				for i=0, physcount do
 					if postable[i] and not postable[i].dontset then
-						local obj = ent:GetPhysicsObjectNum(i)
+						local ent = not pl.rgm.PropRagdoll and ent or ent.rgmPRidtoent[i]
+						local boneid = not pl.rgm.PropRagdoll and i or 0
+
+						local obj = ent:GetPhysicsObjectNum(boneid)
 						local poslen = postable[i].pos:Length()
 						local anglen = Vector(postable[i].ang.p,postable[i].ang.y,postable[i].ang.r):Length()
 
@@ -1085,6 +1282,7 @@ if SERVER then
 						end
 					end
 				end
+
 
 				-- if not pl:GetNWBool("ragdollmover_keydown") then
 			else -- moving nonphysbones
@@ -1182,6 +1380,17 @@ local function GetRecursiveBonesExclusive(ent, boneid, lastvalidbone, tab, physc
 	end
 end
 
+local function GetRecursiveEntities(ents, parentid, parentent, tab, depth)
+	for ent, data in pairs(ents) do
+		if data.parent == parentid then
+			local entdata = { ent = ent, id = data.id, parent = parentent, depth = depth + 1 }
+
+			table.insert(tab, entdata)
+			GetRecursiveEntities(ents, entdata.id, ent, tab, entdata.depth)
+		end
+	end
+end
+
 local function GetModelName(ent)
 	local name = ent:GetModel()
 	local splitname = string.Split(name, "/")
@@ -1222,6 +1431,7 @@ local function CManipSlider(cpanel, text, mode, axis, min, max, dec)
 	end
 
 	function slider:OnValueChanged(value)
+		if ManipSliderUpdating then return end
 		net.Start("rgmAdjustBone")
 		net.WriteInt(mode, 3)
 		net.WriteInt(axis, 3)
@@ -1394,8 +1604,12 @@ local function RGMSelectAllIK()
 end
 
 local function RGMResetAllBones()
+	local pl = LocalPlayer()
+	if not pl.rgm or not pl.rgm.Entity then return end
+
 	net.Start("rgmResetAll")
-	net.WriteUInt(0, 8)
+	net.WriteEntity(pl.rgm.Entity)
+	net.WriteUInt(0, 10)
 	net.WriteBool(true)
 	net.SendToServer()
 end
@@ -1550,13 +1764,15 @@ end
 
 local BonePanel, EntPanel, ConEntPanel
 local Pos1, Pos2, Pos3, Rot1, Rot2, Rot3, Scale1, Scale2, Scale3
+local ManipSliderUpdating = false
 local Gizmo1, Gizmo2, Gizmo3
 local nodes, entnodes, conentnodes
-local HoveredBone, HoveredEnt
+local HoveredBone, HoveredEntBone, HoveredEnt
 local Col4
-local LockMode, LockTo = false, nil
+local LockMode, LockTo = false, { id = nil, ent = nil }
+local IsPropRagdoll, TreeEntities = false, {}
 
-local function SetBoneNodes(bonepanel, ent, sortedbones)
+local function SetBoneNodes(bonepanel, sortedbones)
 
 	nodes = {}
 
@@ -1568,433 +1784,515 @@ local function SetBoneNodes(bonepanel, ent, sortedbones)
 		{ Icon = "icon16/error.png", ToolTip = "#tool.ragdollmover.proceduralbone" },
 	}
 
-	for k, v in ipairs(sortedbones) do
-		local text1 = ent:GetBoneName(v.id)
+	for i, entdata in ipairs(sortedbones) do
+		local ent = entdata.ent
+		nodes[ent] = { id = entdata.id, parent = entdata.parent }
 
-		if not v.parent then
-			nodes[v.id] = bonepanel:AddNode(text1)
-		else
-			nodes[v.id] = nodes[v.parent]:AddNode(text1)
-		end
+		for k, v in ipairs(entdata) do
+			local text1 = ent:GetBoneName(v.id)
 
-		nodes[v.id].Type = v.Type
-		nodes[v.id]:SetExpanded(true)
-
-		nodes[v.id]:SetIcon(BoneTypeSort[v.Type].Icon)
-		nodes[v.id].Label:SetToolTip(BoneTypeSort[v.Type].ToolTip)
-
-		nodes[v.id].DoClick = function()
-
-			if not LockMode then
-				net.Start("rgmSelectBone")
-					net.WriteEntity(ent)
-					net.WriteUInt(v.id, 32)
-				net.SendToServer()
+			if nodes[ent].parent then
+				nodes[ent][v.id] = nodes[nodes[ent].parent][0]:AddNode(text1)
+			elseif v.parent then
+				nodes[ent][v.id] = nodes[ent][v.parent]:AddNode(text1)
 			else
-				if LockMode == 1 then
-					net.Start("rgmLockToBone")
-						net.WriteUInt(v.id, 8)
-						net.WriteUInt(LockTo, 8)
-					net.SendToServer()
-
-					if nodes[LockTo].poslock or nodes[LockTo].anglock then
-						nodes[LockTo]:SetIcon("icon16/lock.png")
-						nodes[LockTo].Label:SetToolTip("#tool.ragdollmover.lockedbone")
-					else
-						nodes[LockTo]:SetIcon(BoneTypeSort[nodes[LockTo].Type].Icon)
-						nodes[LockTo].Label:SetToolTip(BoneTypeSort[nodes[LockTo].Type].ToolTip)
-					end
-				elseif LockMode == 2 then
-					net.Start("rgmLockConstrained")
-						net.WriteEntity(LockTo) -- In this case it isn't really "LockTo", more of "LockThis" but i was lazy so used same variables. Probably once I get to C++ stuff trying to do the same thing would be baaad
-						net.WriteBool(true)
-						net.WriteUInt(v.id, 8)
-					net.SendToServer()
-
-					conentnodes[LockTo]:SetIcon("icon16/brick_link.png")
-					conentnodes[LockTo].Label:SetToolTip(false)
-				end
-
-				LockMode = false
-				LockTo = nil
+				nodes[ent][v.id] = bonepanel:AddNode(text1)
 			end
 
-		end
+			nodes[ent][v.id].Type = v.Type
+			nodes[ent][v.id]:SetExpanded(true)
 
-		nodes[v.id].DoRightClick = function()
-			local pl = LocalPlayer()
-			local bonemenu = DermaMenu(false, bonepanel)
+			nodes[ent][v.id]:SetIcon(BoneTypeSort[v.Type].Icon)
+			nodes[ent][v.id].Label:SetToolTip(BoneTypeSort[v.Type].ToolTip)
 
-			local ResetMenu = bonemenu:AddSubMenu("#tool.ragdollmover.resetmenu")
+			nodes[ent][v.id].DoClick = function()
 
-			option = ResetMenu:AddOption("#tool.ragdollmover.reset", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmResetAll")
-				net.WriteUInt(v.id, 8)
-				net.WriteBool(false)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/connect.png")
-
-			local option = ResetMenu:AddOption("#tool.ragdollmover.resetpos", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmResetPos")
-				net.WriteBool(false)
-				net.WriteUInt(v.id, 8) -- with SFM studiomdl, it seems like upper limit for bones is 256 (counting 0)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/connect.png")
-
-			option = ResetMenu:AddOption("#tool.ragdollmover.resetrot", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmResetAng")
-				net.WriteBool(false)
-				net.WriteUInt(v.id, 8)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/connect.png")
-
-			option = ResetMenu:AddOption("#tool.ragdollmover.resetscale", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmResetScale")
-				net.WriteBool(false)
-				net.WriteUInt(v.id, 8)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/connect.png")
-
-			option = ResetMenu:AddOption("#tool.ragdollmover.resetchildren", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmResetAll")
-				net.WriteUInt(v.id, 8)
-				net.WriteBool(true)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/bricks.png")
-
-			option = ResetMenu:AddOption("#tool.ragdollmover.resetposchildren", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmResetPos")
-				net.WriteBool(true)
-				net.WriteUInt(v.id, 8)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/bricks.png")
-
-			option = ResetMenu:AddOption("#tool.ragdollmover.resetrotchildren", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmResetAng")
-				net.WriteBool(true)
-				net.WriteUInt(v.id, 8)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/bricks.png")
-
-			option = ResetMenu:AddOption("#tool.ragdollmover.resetscalechildren", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmResetScale")
-				net.WriteBool(true)
-				net.WriteUInt(v.id, 8)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/bricks.png")
-
-			local ScaleZeroMenu = bonemenu:AddSubMenu("#tool.ragdollmover.scalezero")
-
-			option = ScaleZeroMenu:AddOption("#tool.ragdollmover.bone", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmScaleZero")
-				net.WriteBool(false)
-				net.WriteUInt(v.id, 8)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/connect.png")
-
-			option = ScaleZeroMenu:AddOption("#tool.ragdollmover.bonechildren", function()
-				if not pl.rgm then return end
-				if not IsValid(pl.rgm.Entity) then return end
-				net.Start("rgmScaleZero")
-				net.WriteBool(true)
-				net.WriteUInt(v.id, 8)
-				net.SendToServer()
-			end)
-			option:SetIcon("icon16/bricks.png")
-
-			bonemenu:AddSpacer()
-
-			if nodes[v.id].bonelock then
-
-				option = bonemenu:AddOption("#tool.ragdollmover.unlockbone", function()
-					if not pl.rgm then return end
-					if not IsValid(pl.rgm.Entity) then return end
-					net.Start("rgmUnlockToBone")
-						net.WriteUInt(v.id, 8)
+				if not LockMode then
+					net.Start("rgmSelectBone")
+						net.WriteEntity(ent)
+						net.WriteUInt(v.id, 10)
 					net.SendToServer()
-				end)
-
-				bonemenu:AddSpacer()
-			elseif nodes[v.id].Type == BONE_PHYSICAL and IsValid(pl.rgm.Entity) and pl.rgm.Entity:GetClass() == "prop_ragdoll" then
-
-				option = bonemenu:AddOption(nodes[v.id].poslock and "#tool.ragdollmover.unlockpos" or "#tool.ragdollmover.lockpos", function()
-					if not pl.rgm then return end
-					if not IsValid(pl.rgm.Entity) then return end
-					net.Start("rgmLockBone")
-						net.WriteUInt(1, 2)
-						net.WriteUInt(v.id, 8)
-					net.SendToServer()
-				end)
-				option:SetIcon(nodes[v.id].poslock and "icon16/lock.png" or "icon16/brick.png")
-
-				option = bonemenu:AddOption(nodes[v.id].anglock and "#tool.ragdollmover.unlockang" or "#tool.ragdollmover.lockang", function()
-					if not pl.rgm then return end
-					if not IsValid(pl.rgm.Entity) then return end
-					net.Start("rgmLockBone")
-						net.WriteUInt(2, 2)
-						net.WriteUInt(v.id, 8)
-					net.SendToServer()
-				end)
-				option:SetIcon(nodes[v.id].anglock and "icon16/lock.png" or "icon16/brick.png")
-
-				option = bonemenu:AddOption("#tool.ragdollmover.lockbone", function()
-					if not pl.rgm then return end
-					if not IsValid(pl.rgm.Entity) then return end
-
+				else
 					if LockMode == 1 then
-						nodes[LockTo]:SetIcon(BoneTypeSort[nodes[LockTo].Type].Icon)
-						nodes[LockTo].Label:SetToolTip(BoneTypeSort[nodes[LockTo].Type].ToolTip)
+						net.Start("rgmLockToBone")
+							net.WriteEntity(ent)
+							net.WriteUInt(v.id, 10)
+							net.WriteEntity(LockTo.ent)
+							net.WriteUInt(LockTo.id, 10)
+						net.SendToServer()
+
+						if nodes[LockTo.ent][LockTo.id].poslock or nodes[LockTo.ent][LockTo.id].anglock then
+							nodes[LockTo.ent][LockTo.id]:SetIcon("icon16/lock.png")
+							nodes[LockTo.ent][LockTo.id].Label:SetToolTip("#tool.ragdollmover.lockedbone")
+						else
+							nodes[LockTo.ent][LockTo.id]:SetIcon(BoneTypeSort[nodes[LockTo.ent][LockTo.id].Type].Icon)
+							nodes[LockTo.ent][LockTo.id].Label:SetToolTip(BoneTypeSort[nodes[LockTo.ent][LockTo.id].Type].ToolTip)
+						end
 					elseif LockMode == 2 then
-						conentnodes[LockTo]:SetIcon("icon16/brick_link.png")
-						conentnodes[LockTo].Label:SetToolTip(false)
+						net.Start("rgmLockConstrained")
+							net.WriteEntity(ent)
+							net.WriteEntity(LockTo.id) -- In this case it isn't really "LockTo", more of "LockThis" but i was lazy so used same variables. Probably once I get to C++ stuff trying to do the same thing would be baaad
+							net.WriteBool(true)
+							net.WriteUInt(v.id, 8)
+						net.SendToServer()
+
+						conentnodes[LockTo.id]:SetIcon("icon16/brick_link.png")
+						conentnodes[LockTo.id].Label:SetToolTip(false)
 					end
 
-					LockMode = 1
-					LockTo = v.id
-
-					surface.PlaySound("buttons/button9.wav")
-					nodes[v.id]:SetIcon("icon16/brick_add.png")
-					nodes[v.id].Label:SetToolTip("#tool.ragdollmover.bonetolock")
-				end)
-				option:SetIcon("icon16/lock.png")
-
-				bonemenu:AddSpacer()
-			end
-
-			bonemenu:AddOption("#tool.ragdollmover.putgizmopos", function()
-				local pl = LocalPlayer()
-				if not pl.rgm or not IsValid(pl.rgm.Entity) then return end
-
-				local ent = pl.rgm.Entity
-				local bone = v.id
-				local pos = ent:GetBonePosition(bone)
-				if pos == ent:GetPos() then
-					local matrix = ent:GetBoneMatrix(bone)
-					pos = matrix:GetTranslation()
+					LockMode = false
+					LockTo = { id = nil, ent = nil }
 				end
 
-				net.Start("rgmSetGizmoToBone")
-				net.WriteVector(pos)
-				net.SendToServer()
-			end)
+			end
 
-			local x, y = bonepanel:LocalToScreen(5, 0)
+			nodes[ent][v.id].DoRightClick = function()
+				local bonemenu = DermaMenu(false, bonepanel)
 
-			bonemenu:Open(x)
-		end
+				local ResetMenu = bonemenu:AddSubMenu("#tool.ragdollmover.resetmenu")
 
-		nodes[v.id].Label.OnCursorEntered = function()
-			HoveredBone = v.id
-		end
+				local option = ResetMenu:AddOption("#tool.ragdollmover.reset", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmResetAll")
+					net.WriteEntity(ent)
+					net.WriteUInt(v.id, 10)
+					net.WriteBool(false)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/connect.png")
 
-		nodes[v.id].Label.OnCursorExited = function()
-			HoveredBone = nil
-		end
+				option = ResetMenu:AddOption("#tool.ragdollmover.resetpos", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmResetPos")
+					net.WriteEntity(ent)
+					net.WriteBool(false)
+					net.WriteUInt(v.id, 10) -- with SFM studiomdl, it seems like upper limit for bones is 512 (counting 0)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/connect.png")
 
-		local XSize = nodes[v.id].Label:GetTextSize()
-		local currentwidth = XSize + (v.depth * 17)
-		if currentwidth > width then
-			width = currentwidth
+				option = ResetMenu:AddOption("#tool.ragdollmover.resetrot", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmResetAng")
+					net.WriteEntity(ent)
+					net.WriteBool(false)
+					net.WriteUInt(v.id, 10)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/connect.png")
+
+				option = ResetMenu:AddOption("#tool.ragdollmover.resetscale", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmResetScale")
+					net.WriteEntity(ent)
+					net.WriteBool(false)
+					net.WriteUInt(v.id, 10)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/connect.png")
+
+				option = ResetMenu:AddOption("#tool.ragdollmover.resetchildren", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmResetAll")
+					net.WriteEntity(ent)
+					net.WriteUInt(v.id, 10)
+					net.WriteBool(true)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/bricks.png")
+
+				option = ResetMenu:AddOption("#tool.ragdollmover.resetposchildren", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmResetPos")
+					net.WriteEntity(ent)
+					net.WriteBool(true)
+					net.WriteUInt(v.id, 10)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/bricks.png")
+
+				option = ResetMenu:AddOption("#tool.ragdollmover.resetrotchildren", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmResetAng")
+					net.WriteEntity(ent)
+					net.WriteBool(true)
+					net.WriteUInt(v.id, 10)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/bricks.png")
+
+				option = ResetMenu:AddOption("#tool.ragdollmover.resetscalechildren", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmResetScale")
+					net.WriteEntity(ent)
+					net.WriteBool(true)
+					net.WriteUInt(v.id, 10)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/bricks.png")
+
+				local ScaleZeroMenu = bonemenu:AddSubMenu("#tool.ragdollmover.scalezero")
+
+				option = ScaleZeroMenu:AddOption("#tool.ragdollmover.bone", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmScaleZero")
+					net.WriteEntity(ent)
+					net.WriteBool(false)
+					net.WriteUInt(v.id, 10)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/connect.png")
+
+				option = ScaleZeroMenu:AddOption("#tool.ragdollmover.bonechildren", function()
+					if not IsValid(ent) then return end
+					net.Start("rgmScaleZero")
+					net.WriteEntity(ent)
+					net.WriteBool(true)
+					net.WriteUInt(v.id, 10)
+					net.SendToServer()
+				end)
+				option:SetIcon("icon16/bricks.png")
+
+				bonemenu:AddSpacer()
+
+				if nodes[ent][v.id].bonelock then
+
+					option = bonemenu:AddOption("#tool.ragdollmover.unlockbone", function()
+						if not IsValid(ent) then return end
+						net.Start("rgmUnlockToBone")
+							net.WriteEntity(ent)
+							net.WriteUInt(v.id, 10)
+						net.SendToServer()
+					end)
+
+					bonemenu:AddSpacer()
+				elseif nodes[ent][v.id].Type == BONE_PHYSICAL and IsValid(ent) and ( ent:GetClass() == "prop_ragdoll" or IsPropRagdoll ) then
+
+					option = bonemenu:AddOption(nodes[ent][v.id].poslock and "#tool.ragdollmover.unlockpos" or "#tool.ragdollmover.lockpos", function()
+						if not IsValid(ent) then return end
+						net.Start("rgmLockBone")
+							net.WriteEntity(ent)
+							net.WriteUInt(1, 2)
+							net.WriteUInt(v.id, 10)
+						net.SendToServer()
+					end)
+					option:SetIcon(nodes[ent][v.id].poslock and "icon16/lock.png" or "icon16/brick.png")
+
+					option = bonemenu:AddOption(nodes[ent][v.id].anglock and "#tool.ragdollmover.unlockang" or "#tool.ragdollmover.lockang", function()
+						if not IsValid(ent) then return end
+						net.Start("rgmLockBone")
+							net.WriteEntity(ent)
+							net.WriteUInt(2, 2)
+							net.WriteUInt(v.id, 10)
+						net.SendToServer()
+					end)
+					option:SetIcon(nodes[ent][v.id].anglock and "icon16/lock.png" or "icon16/brick.png")
+
+					option = bonemenu:AddOption("#tool.ragdollmover.lockbone", function()
+						if not IsValid(ent) then return end
+
+						if LockMode == 1 then
+							nodes[LockTo.ent][LockTo.id]:SetIcon(BoneTypeSort[nodes[LockTo.ent][LockTo.id].Type].Icon)
+							nodes[LockTo.ent][LockTo.id].Label:SetToolTip(BoneTypeSort[nodes[LockTo.ent][LockTo.id].Type].ToolTip)
+						elseif LockMode == 2 then
+							conentnodes[LockTo.id]:SetIcon("icon16/brick_link.png")
+							conentnodes[LockTo.id].Label:SetToolTip(false)
+						end
+
+						LockMode = 1
+						LockTo = { id = v.id, ent = ent }
+
+						surface.PlaySound("buttons/button9.wav")
+						nodes[ent][v.id]:SetIcon("icon16/brick_add.png")
+						nodes[ent][v.id].Label:SetToolTip("#tool.ragdollmover.bonetolock")
+					end)
+					option:SetIcon("icon16/lock.png")
+
+					bonemenu:AddSpacer()
+				end
+
+				bonemenu:AddOption("#tool.ragdollmover.putgizmopos", function()
+					if not IsValid(ent) then return end
+
+					local bone = v.id
+					local pos = ent:GetBonePosition(bone)
+					if pos == ent:GetPos() then
+						local matrix = ent:GetBoneMatrix(bone)
+						pos = matrix:GetTranslation()
+					end
+
+					net.Start("rgmSetGizmoToBone")
+					net.WriteVector(pos)
+					net.SendToServer()
+				end)
+
+				local x, y = bonepanel:LocalToScreen(5, 0)
+
+				bonemenu:Open(x)
+			end
+
+			nodes[ent][v.id].Label.OnCursorEntered = function()
+				HoveredBone = v.id
+				HoveredEntBone = ent
+			end
+
+			nodes[ent][v.id].Label.OnCursorExited = function()
+				HoveredBone = nil
+				HoveredEntBone = nil
+			end
+
+			local XSize = nodes[ent][v.id].Label:GetTextSize()
+			local currentwidth = XSize + ((v.depth + entdata.depth - 1) * 17)
+			if currentwidth > width then
+				width = currentwidth
+			end
 		end
 	end
 
 	bonepanel:UpdateWidth(width + 8 + 32 + 16)
 end
 
-local function RGMBuildBoneMenu(ent, bonepanel)
+local function RGMBuildBoneMenu(ents, selectedent, bonepanel)
 	bonepanel:Clear()
-	if not IsValid(ent) then return end
+	if not IsValid(selectedent) then return end
 	local sortedbones = {}
+	local count = 0
 
-	local num = ent:GetBoneCount() - 1 -- first we find all rootbones and their children
-	for v = 0, num do
-		if ent:GetBoneName(v) == "__INVALIDBONE__" then continue end
+	for ent, data in pairs(ents) do
+		if not IsValid(ent) then continue end
 
-		if ent:GetBoneParent(v) == -1 then
-			local bone = { id = v, Type = BONE_NONPHYSICAL, depth = 1 }
-			if ent:BoneHasFlag(v, 4) then -- BONE_ALWAYS_PROCEDURAL flag
-				bone.Type = BONE_PROCEDURAL
-			end
+		if not data.parent then
+			local entdata = { ent = ent, id = data.id, depth = 1 }
+			table.insert(sortedbones, entdata)
 
-			table.insert(sortedbones, bone)
-			GetRecursiveBones(ent, v, sortedbones, bone.depth)
+			GetRecursiveEntities(ents, entdata.id, ent, sortedbones, entdata.depth)
 		end
 	end
 
-	SetBoneNodes(bonepanel, ent, sortedbones)
+	for id, entdata in ipairs(sortedbones) do
+		local ent = entdata.ent
+		local num = ent:GetBoneCount() - 1 -- first we find all rootbones and their children
+		for v = 0, num do
+			if ent:GetBoneName(v) == "__INVALIDBONE__" then continue end
+
+			if ent:GetBoneParent(v) == -1 then
+				local bone = { id = v, Type = BONE_NONPHYSICAL, depth = 1 }
+				if ent:BoneHasFlag(v, 4) then -- BONE_ALWAYS_PROCEDURAL flag
+					bone.Type = BONE_PROCEDURAL
+				end
+
+				table.insert(entdata, bone)
+				GetRecursiveBones(ent, v, entdata, bone.depth)
+			end
+		end
+		count = count + 1
+	end
+
+	SetBoneNodes(bonepanel, sortedbones)
 
 	net.Start("rgmAskForPhysbones")
-		net.WriteEntity(ent)
+		net.WriteUInt(count, 13)
+		for ent, _ in pairs(ents) do
+			net.WriteEntity(ent)
+		end
 	net.SendToServer()
 
-	if ent:IsEffectActive(EF_BONEMERGE) then
-		net.Start("rgmAskForParented")
-			net.WriteEntity(ent)
-		net.SendToServer()
+	for ent, _ in pairs(ents) do
+		if ent:IsEffectActive(EF_BONEMERGE) then
+			net.Start("rgmAskForParented")
+				net.WriteUInt(count, 13)
+				for ent, _ in pairs(ents) do
+					net.WriteEntity(ent)
+				end
+			net.SendToServer()
+			break
+		end
 	end
 end
 
 local function ShowOnlyPhysNodes(ent, bonepanel)
 	bonepanel:Clear()
 	if not IsValid(ent) then return end
+	local count = 0
+
+	for ent, data in pairs(TreeEntities) do
+		count = count + 1
+	end
 
 	net.Start("rgmAskForNodeUpdatePhysics")
 		net.WriteBool(true)
-		net.WriteEntity(ent)
+		net.WriteUInt(count, 13)
+
+		for ent, _ in pairs(TreeEntities) do
+			net.WriteEntity(ent)
+		end
 	net.SendToServer()
 end
 
 local function ShowOnlyNonPhysNodes(ent, bonepanel)
 	bonepanel:Clear()
 	if not IsValid(ent) then return end
+	local count = 0
+
+	for ent, data in pairs(TreeEntities) do
+		count = count + 1
+	end
 
 	net.Start("rgmAskForNodeUpdatePhysics")
 		net.WriteBool(false)
-		net.WriteEntity(ent)
+		net.WriteUInt(count, 13)
+
+		for ent, _ in pairs(TreeEntities) do
+			net.WriteEntity(ent)
+		end
 	net.SendToServer()
 end
 
-local function UpdateBoneNodes(ent, bonepanel, physIDs, isphys)
+local function UpdateBoneNodes(bonepanel, physIDs, isphys)
 	local sortedbones = {}
+	local count = 0
 
-	local num = ent:GetBoneCount() - 1
-	for v = 0, num do
-		if ent:GetBoneName(v) == "__INVALIDBONE__" then continue end
+	for ent, data in pairs(TreeEntities) do
+		if not IsValid(ent) then continue end
 
-		if ent:GetBoneParent(v) == -1 then
-			local bone = { id = v, Type = BONE_NONPHYSICAL, depth = 1 }
-			if ent:BoneHasFlag(v, 4) then
-				bone.Type = BONE_PROCEDURAL
-			end
-			if physIDs[v] then
-				bone.Type = BONE_PHYSICAL
-			end
+		if not data.parent then
+			local entdata = { ent = ent, id = data.id, depth = 1 }
+			table.insert(sortedbones, entdata)
 
-			table.insert(sortedbones, bone)
-			GetRecursiveBonesExclusive(ent, v, v, sortedbones, physIDs, isphys, bone.depth)
+			GetRecursiveEntities(TreeEntities, entdata.id, ent, sortedbones, entdata.depth)
 		end
 	end
 
-	SetBoneNodes(bonepanel, ent, sortedbones)
+	for id, entdata in ipairs(sortedbones) do
+		local ent = entdata.ent
+
+		local num = ent:GetBoneCount() - 1
+		for v = 0, num do
+			if ent:GetBoneName(v) == "__INVALIDBONE__" then continue end
+
+			if ent:GetBoneParent(v) == -1 then
+				local bone = { id = v, Type = BONE_NONPHYSICAL, depth = 1 }
+				if ent:BoneHasFlag(v, 4) then
+					bone.Type = BONE_PROCEDURAL
+				end
+				if physIDs[ent][v] then
+					bone.Type = BONE_PHYSICAL
+				end
+
+				table.insert(entdata, bone)
+				GetRecursiveBonesExclusive(ent, v, v, entdata, physIDs[ent], isphys, bone.depth)
+			end
+		end
+		count = count + 1
+	end
+
+	SetBoneNodes(bonepanel, sortedbones)
 
 	if isphys then
 		net.Start("rgmAskForPhysbones")
-			net.WriteEntity(ent)
+			net.WriteUInt(count, 13)
+			for ent, _ in pairs(TreeEntities) do
+				net.WriteEntity(ent)
+			end
 		net.SendToServer()
 	end
 
-	if ent:IsEffectActive(EF_BONEMERGE) then
-		net.Start("rgmAskForParented")
-			net.WriteEntity(ent)
-		net.SendToServer()
+	for ent, _ in pairs(TreeEntities) do
+		if ent:IsEffectActive(EF_BONEMERGE) then
+			net.Start("rgmAskForParented")
+				net.WriteUInt(count, 13)
+				for ent, _ in pairs(TreeEntities) do
+					net.WriteEntity(ent)
+				end
+			net.SendToServer()
+			break
+		end
 	end
 end
 
-local function RGMBuildEntMenu(parent, children, entpanel)
+local function RGMBuildEntMenu(ents, children, entpanel)
 	entpanel:Clear()
-	if not IsValid(parent) then return end
-
-	local LockSelection = GetConVar("ragdollmover_lockselected")
-	local width
+	local width = 0
 
 	entnodes = {}
 
-	entnodes[parent] = entpanel:AddNode(GetModelName(parent))
-	entnodes[parent]:SetExpanded(true)
+	for parent, entdata in pairs(ents) do
+		if not IsValid(parent) then continue end
 
-	entnodes[parent].DoClick = function()
-		net.Start("rgmSelectEntity")
-			net.WriteEntity(parent)
-			net.WriteBool(LockSelection:GetBool())
-		net.SendToServer()
-	end
+		local LockSelection = GetConVar("ragdollmover_lockselected")
 
-	entnodes[parent].Label.OnCursorEntered = function()
-		HoveredEnt = parent
-	end
+		entnodes[parent] = entpanel:AddNode(GetModelName(parent))
+		entnodes[parent]:SetExpanded(true)
 
-	entnodes[parent].Label.OnCursorExited = function()
-		HoveredEnt = nil
-	end
-
-	local XSize = entnodes[parent].Label:GetTextSize()
-	width = XSize + 17
-
-	local sortchildren = {depth = 1}
-
-	local function RecursiveChildrenSort(parent, sorttable, depth)
-		for k, v in ipairs(children) do
-			if v:GetParent() ~= parent then continue end
-			table.insert(sorttable, v)
-			sorttable[v] = {}
-			sorttable[v].depth = depth + 1
-			RecursiveChildrenSort(v, sorttable[v], depth + 1)
+		entnodes[parent].DoClick = function()
+			net.Start("rgmSelectEntity")
+				net.WriteEntity(parent)
+				net.WriteBool(LockSelection:GetBool())
+			net.SendToServer()
 		end
-	end
 
-	RecursiveChildrenSort(parent, sortchildren, sortchildren.depth)
-
-	local function MakeChildrenList(parent, sorttable)
-		local depth = sorttable.depth
-		for k, v in ipairs(sorttable) do
-			if not IsValid(v) or not isstring(v:GetModel()) then continue end
-			entnodes[v] = entnodes[parent]:AddNode(GetModelName(v))
-			entnodes[v]:SetExpanded(true)
-
-			entnodes[v].DoClick = function()
-				net.Start("rgmSelectEntity")
-					net.WriteEntity(v)
-					net.WriteBool(LockSelection:GetBool())
-				net.SendToServer()
-			end
-
-			entnodes[v].Label.OnCursorEntered = function()
-				HoveredEnt = v
-			end
-
-			entnodes[v].Label.OnCursorExited = function()
-				HoveredEnt = nil
-			end
-
-			XSize = entnodes[v].Label:GetTextSize()
-			local currentwidth = XSize + (depth * 17)
-
-			if currentwidth > width then
-				width = currentwidth
-			end
-
-			MakeChildrenList(v, sorttable[v])
+		entnodes[parent].Label.OnCursorEntered = function()
+			HoveredEnt = parent
 		end
-	end
 
-	MakeChildrenList(parent, sortchildren)
+		entnodes[parent].Label.OnCursorExited = function()
+			HoveredEnt = nil
+		end
+
+		local XSize = entnodes[parent].Label:GetTextSize() + 17
+		if XSize > width then
+			width = XSize
+		end
+
+		local sortchildren = {depth = 1}
+
+		local function RecursiveChildrenSort(ent, sorttable, depth)
+			for k, v in ipairs(children[parent]) do
+				if v:GetParent() ~= ent then continue end
+				table.insert(sorttable, v)
+				sorttable[v] = {}
+				sorttable[v].depth = depth + 1
+				RecursiveChildrenSort(v, sorttable[v], depth + 1)
+			end
+		end
+
+		RecursiveChildrenSort(parent, sortchildren, sortchildren.depth)
+
+		local function MakeChildrenList(parent, sorttable)
+			local depth = sorttable.depth
+			for k, v in ipairs(sorttable) do
+				if not IsValid(v) or not isstring(v:GetModel()) then continue end
+				entnodes[v] = entnodes[parent]:AddNode(GetModelName(v))
+				entnodes[v]:SetExpanded(true)
+
+				entnodes[v].DoClick = function()
+					net.Start("rgmSelectEntity")
+						net.WriteEntity(v)
+						net.WriteBool(LockSelection:GetBool())
+					net.SendToServer()
+				end
+
+				entnodes[v].Label.OnCursorEntered = function()
+					HoveredEnt = v
+				end
+
+				entnodes[v].Label.OnCursorExited = function()
+					HoveredEnt = nil
+				end
+
+				XSize = entnodes[v].Label:GetTextSize()
+				local currentwidth = XSize + (depth * 17)
+
+				if currentwidth > width then
+					width = currentwidth
+				end
+
+				MakeChildrenList(v, sorttable[v])
+			end
+		end
+
+		MakeChildrenList(parent, sortchildren)
+	end
 
 	entpanel:UpdateWidth(width + 8 + 32 + 16)
 end
@@ -2028,23 +2326,24 @@ local function RGMBuildConstrainedEnts(parent, children, entpanel)
 					net.WriteEntity(ent)
 				net.SendToServer()
 			else
-				if parent:GetClass() ~= "prop_ragdoll" then
+				if parent:GetClass() ~= "prop_ragdoll" and not IsPropRagdoll then
 					net.Start("rgmLockConstrained")
+						net.WriteEntity(parent)
 						net.WriteEntity(ent)
 						net.WriteBool(false)
 					net.SendToServer()
 				else
 
 					if LockMode == 1 then
-						nodes[LockTo]:SetIcon(BoneTypeSort[nodes[LockTo].Type].Icon)
-						nodes[LockTo].Label:SetToolTip(BoneTypeSort[nodes[LockTo].Type].ToolTip)
+						nodes[LockTo.ent][LockTo.id]:SetIcon(BoneTypeSort[nodes[LockTo.ent][LockTo.id].Type].Icon)
+						nodes[LockTo.ent][LockTo.id].Label:SetToolTip(BoneTypeSort[nodes[LockTo.ent][LockTo.id].Type].ToolTip)
 					elseif LockMode == 2 then
-						conentnodes[LockTo]:SetIcon("icon16/brick_link.png")
-						conentnodes[LockTo].Label:SetToolTip(false)
+						conentnodes[LockTo.id]:SetIcon("icon16/brick_link.png")
+						conentnodes[LockTo.id].Label:SetToolTip(false)
 					end
 
 					LockMode = 2
-					LockTo = ent
+					LockTo = { id = ent, ent = ent }
 
 					surface.PlaySound("buttons/button9.wav")
 					conentnodes[ent]:SetIcon("icon16/brick_edit.png")
@@ -2075,7 +2374,7 @@ local function RGMMakeBoneButtonPanel(cat, cpanel)
 	parentpanel.ShowAll.DoClick = function()
 		local ent = LocalPlayer().rgm.Entity
 		if not IsValid(ent) or not IsValid(BonePanel) then return end
-		RGMBuildBoneMenu(ent, BonePanel)
+		RGMBuildBoneMenu(TreeEntities, ent, BonePanel)
 	end
 
 	parentpanel.ShowPhys = vgui.Create("DButton", parentpanel)
@@ -2224,6 +2523,8 @@ local function UpdateManipulationSliders(boneid, ent)
 	local pos, rot, scale = ent:GetManipulateBonePosition(boneid), ent:GetManipulateBoneAngles(boneid), ent:GetManipulateBoneScale(boneid)
 	rot:Normalize()
 
+	ManipSliderUpdating = true
+
 	Pos1:SetValue(pos[1])
 	Pos2:SetValue(pos[2])
 	Pos3:SetValue(pos[3])
@@ -2236,6 +2537,8 @@ local function UpdateManipulationSliders(boneid, ent)
 	Scale2:SetValue(scale[2])
 	Scale3:SetValue(scale[3])
 
+	ManipSliderUpdating = false
+
 end
 
 net.Receive("rgmUpdateSliders", function(len)
@@ -2244,26 +2547,56 @@ net.Receive("rgmUpdateSliders", function(len)
 end)
 
 net.Receive("rgmUpdateLists", function(len)
-	local ent = net.ReadEntity()
-	local children, physchildren = {}, {}
-	local pl = LocalPlayer()
+	IsPropRagdoll = net.ReadBool()
 
-	for i = 1, net.ReadUInt(32) do
-		children[i] = net.ReadEntity()
+	local ents, children = {}, {}
+
+	if IsPropRagdoll then
+		for i = 1, net.ReadUInt(13) do
+			local ent = net.ReadEntity()
+			local data = {}
+			data.id = net.ReadUInt(13)
+
+			if net.ReadBool() then
+				data.parent = net.ReadUInt(13)
+			end
+
+			ents[ent] = data
+
+			children[ent] = {}
+
+			for i = 1, net.ReadUInt(13) do
+				children[ent][i] = net.ReadEntity()
+			end
+		end
 	end
 
-	for i = 1, net.ReadUInt(32) do
+	local selectedent = net.ReadEntity()
+	if not ents[selectedent] then
+		ents[selectedent] = {id = -1}
+	end
+
+	TreeEntities = ents
+
+	local physchildren = {}
+	children[selectedent] = {}
+
+	for i = 1, net.ReadUInt(13) do
+		children[selectedent][i] = net.ReadEntity()
+	end
+
+	for i = 1, net.ReadUInt(13) do
 		physchildren[i] = net.ReadEntity()
 	end
 
 	if IsValid(BonePanel) then
-		RGMBuildBoneMenu(ent, BonePanel)
+		RGMBuildBoneMenu(ents, selectedent, BonePanel)
 	end
 	if IsValid(EntPanel) then
-		RGMBuildEntMenu(ent, children, EntPanel)
+		RGMBuildEntMenu(ents, children, EntPanel)
 	end
 	if IsValid(ConEntPanel) then
-		RGMBuildConstrainedEnts(ent, physchildren, ConEntPanel)
+		RGMBuildConstrainedEnts(selectedent, physchildren, ConEntPanel)
 	end
 end)
 
@@ -2279,12 +2612,22 @@ net.Receive("rgmUpdateEntInfo", function(len)
 	local ent = net.ReadEntity()
 	local physchildren = {}
 
-	for i = 1, net.ReadUInt(32) do
+	local ents = {}
+
+	IsPropRagdoll =  false
+	if TreeEntities[ent] then
+		IsPropRagdoll = true
+		ents = TreeEntities
+	else
+		ents[ent] = { id = -1 }
+	end
+
+	for i = 1, net.ReadUInt(13) do
 		physchildren[i] = net.ReadEntity()
 	end
 
 	if IsValid(BonePanel) then
-		RGMBuildBoneMenu(ent, BonePanel)
+		RGMBuildBoneMenu(ents, ent, BonePanel)
 	end
 	if IsValid(ConEntPanel) then
 		RGMBuildConstrainedEnts(ent, physchildren, ConEntPanel)
@@ -2292,88 +2635,101 @@ net.Receive("rgmUpdateEntInfo", function(len)
 end)
 
 net.Receive("rgmAskForPhysbonesResponse", function(len)
-	local count = net.ReadUInt(8)
-	for i = 0, count do
-		local bone = net.ReadUInt(8)
-		local poslock = net.ReadBool()
-		local anglock = net.ReadBool()
-		local bonelock = net.ReadBool()
+	local entcount = net.ReadUInt(13)
+	for j = 1, entcount do
+		local ent = net.ReadEntity()
 
-		if bone then
-			nodes[bone].Type = BONE_PHYSICAL
-			nodes[bone].poslock = poslock
-			nodes[bone].anglock = anglock
-			nodes[bone].bonelock = bonelock
+		local count = net.ReadUInt(8)
+		for i = 0, count do
+			local bone = net.ReadUInt(8)
+			local poslock = net.ReadBool()
+			local anglock = net.ReadBool()
+			local bonelock = net.ReadBool()
 
-			if LockMode == 1 and bone == LockTo then
-				nodes[bone]:SetIcon("icon16/brick_add.png")
-				nodes[bone].Label:SetToolTip("#tool.ragdollmover.bonetolock")
-			elseif bonelock then
-				nodes[bone]:SetIcon("icon16/lock_go.png")
-				nodes[bone].Label:SetToolTip("#tool.ragdollmover.lockedbonetobone")
-			elseif anglock or poslock then
-				nodes[bone]:SetIcon("icon16/lock.png")
-				nodes[bone].Label:SetToolTip("#tool.ragdollmover.lockedbone")
-			else
-				nodes[bone]:SetIcon("icon16/brick.png")
-				nodes[bone].Label:SetToolTip("#tool.ragdollmover.physbone")
+			if bone then
+				nodes[ent][bone].Type = BONE_PHYSICAL
+				nodes[ent][bone].poslock = poslock
+				nodes[ent][bone].anglock = anglock
+				nodes[ent][bone].bonelock = bonelock
+
+				if LockMode == 1 and bone == LockTo.id and ent == LockTo.ent then
+					nodes[ent][bone]:SetIcon("icon16/brick_add.png")
+					nodes[ent][bone].Label:SetToolTip("#tool.ragdollmover.bonetolock")
+				elseif bonelock then
+					nodes[ent][bone]:SetIcon("icon16/lock_go.png")
+					nodes[ent][bone].Label:SetToolTip("#tool.ragdollmover.lockedbonetobone")
+				elseif anglock or poslock then
+					nodes[ent][bone]:SetIcon("icon16/lock.png")
+					nodes[ent][bone].Label:SetToolTip("#tool.ragdollmover.lockedbone")
+				else
+					nodes[ent][bone]:SetIcon("icon16/brick.png")
+					nodes[ent][bone].Label:SetToolTip("#tool.ragdollmover.physbone")
+				end
 			end
 		end
 	end
 end)
 
 net.Receive("rgmAskForParentedResponse", function(len)
-	local count = net.ReadUInt(32)
+	local entcount = net.ReadUInt(13)
 
-	for i = 1, count do
-		local bone = net.ReadUInt(32)
+	for i = 1, entcount do
+		local ent = net.ReadEntity()
+		local count = net.ReadUInt(10)
 
-		if nodes[bone] then
-			nodes[bone].Type = BONE_PARENTED
-			nodes[bone]:SetIcon("icon16/stop.png")
-			nodes[bone].Label:SetToolTip("#tool.ragdollmover.parentedbone")
+		for i = 1, count do
+			local bone = net.ReadUInt(10)
+
+			if nodes[ent][bone] then
+				nodes[ent][bone].Type = BONE_PARENTED
+				nodes[ent][bone]:SetIcon("icon16/stop.png")
+				nodes[ent][bone].Label:SetToolTip("#tool.ragdollmover.parentedbone")
+			end
 		end
 	end
 end)
 
 net.Receive("rgmLockBoneResponse", function(len)
-	local boneid = net.ReadUInt(32)
+	local ent = net.ReadEntity()
+	local boneid = net.ReadUInt(10)
 	local poslock = net.ReadBool()
 	local anglock = net.ReadBool()
 
-	nodes[boneid].poslock = poslock
-	nodes[boneid].anglock = anglock
+	nodes[ent][boneid].poslock = poslock
+	nodes[ent][boneid].anglock = anglock
 
 	if poslock or anglock then
-		nodes[boneid]:SetIcon("icon16/lock.png")
-		nodes[boneid].Label:SetToolTip("#tool.ragdollmover.lockedbone")
+		nodes[ent][boneid]:SetIcon("icon16/lock.png")
+		nodes[ent][boneid].Label:SetToolTip("#tool.ragdollmover.lockedbone")
 	else
-		nodes[boneid]:SetIcon("icon16/brick.png")
-		nodes[boneid].Label:SetToolTip("#tool.ragdollmover.physbone")
+		nodes[ent][boneid]:SetIcon("icon16/brick.png")
+		nodes[ent][boneid].Label:SetToolTip("#tool.ragdollmover.physbone")
 	end
 end)
 
 net.Receive("rgmLockToBoneResponse", function(len)
-	local lockbone = net.ReadUInt(8)
+	local ent = net.ReadEntity()
+	local lockbone = net.ReadUInt(10)
 
-	if nodes[lockbone] then
-		nodes[lockbone].bonelock = true
-		nodes[lockbone].poslock = false
-		nodes[lockbone].anglock = false
-		nodes[lockbone]:SetIcon("icon16/lock_go.png")
-		nodes[lockbone].Label:SetToolTip("#tool.ragdollmover.lockedbonetobone")
+	if nodes[ent][lockbone] then
+		nodes[ent][lockbone].bonelock = true
+		nodes[ent][lockbone].poslock = false
+		nodes[ent][lockbone].anglock = false
+		nodes[ent][lockbone]:SetIcon("icon16/lock_go.png")
+		nodes[ent][lockbone].Label:SetToolTip("#tool.ragdollmover.lockedbonetobone")
 
 		rgmDoNotification(RGM_NOTIFY.BONELOCK_SUCCESS.id)
 	end
 end)
 
 net.Receive("rgmUnlockToBoneResponse", function(len)
-	local unlockbone = net.ReadUInt(8)
+	local ent = net.ReadEntity()
+	local unlockbone = net.ReadUInt(10)
 
-	if nodes[unlockbone] then
-		nodes[unlockbone].bonelock = false
-		nodes[unlockbone]:SetIcon("icon16/brick.png")
-		nodes[unlockbone].Label:SetToolTip("#tool.ragdollmover.physbone")
+	if nodes[ent][unlockbone] then
+		nodes[ent][unlockbone].bonelock = false
+		nodes[ent][unlockbone]:SetIcon("icon16/brick.png")
+		nodes[ent][unlockbone].Label:SetToolTip("#tool.ragdollmover.physbone")
 	end
 end)
 
@@ -2406,22 +2762,22 @@ net.Receive("rgmSelectBoneResponse", function(len)
 
 	local isphys = net.ReadBool()
 	local ent = net.ReadEntity()
-	local boneid = net.ReadUInt(32)
+	local boneid = net.ReadUInt(10)
 
 	if IsValid(ent) and boneid then
 		UpdateManipulationSliders(boneid, ent)
 	end
 
 	if nodes then
-		if ent:GetClass() == "prop_ragdoll" and isphys and nodes[boneid] then
+		if ent:GetClass() == "prop_ragdoll" and isphys and nodes[ent] and nodes[ent][boneid] then
 			SetVisiblePhysControls(true)
 		else
 			SetVisiblePhysControls(false)
 		end
 	end
 
-	if IsValid(BonePanel) and nodes then
-		BonePanel:SetSelectedItem(nodes[boneid])
+	if IsValid(BonePanel) and nodes and nodes[ent] then
+		BonePanel:SetSelectedItem(nodes[ent][boneid])
 
 		Col4:InvalidateLayout()
 	end
@@ -2429,16 +2785,25 @@ end)
 
 net.Receive("rgmAskForNodeUpdatePhysicsResponse", function(len)
 	local isphys = net.ReadBool()
-	local ent = net.ReadEntity()
-	local physIDs = {}
+	local entcount = net.ReadUInt(13)
+	local physIDs, ents = {}
 
-	for i = 0, net.ReadUInt(8) do
-		local id = net.ReadUInt(8)
-		physIDs[id] = true
+	for i = 1, entcount do
+		local ent = net.ReadEntity()
+		physIDs[ent] = {}
+
+		local count = net.ReadUInt(8)
+		if count ~= 0 then
+			for i = 0, count - 1 do
+				local id = net.ReadUInt(8)
+				physIDs[ent][id] = true
+			end
+		end
 	end
 
-	if not IsValid(ent) or not IsValid(BonePanel) then return end
-	UpdateBoneNodes(ent, BonePanel, physIDs, isphys)
+
+	if not IsValid(BonePanel) then return end
+	UpdateBoneNodes(BonePanel, physIDs, isphys)
 end)
 
 net.Receive("rgmNotification", function(len)
@@ -2505,9 +2870,9 @@ function TOOL:DrawHUD()
 		rgm.DrawSkeleton(ent)
 	end
 
-	if IsValid(ent) and EntityFilter(ent) and HoveredBone then
-		rgm.DrawBoneConnections(ent, HoveredBone)
-		rgm.DrawBoneName(ent,HoveredBone)
+	if IsValid(HoveredEntBone) and EntityFilter(HoveredEntBone) and HoveredBone then
+		rgm.DrawBoneConnections(HoveredEntBone, HoveredBone)
+		rgm.DrawBoneName(HoveredEntBone,HoveredBone)
 	elseif IsValid(HoveredEnt) and EntityFilter(HoveredEnt) then
 		rgm.DrawEntName(HoveredEnt)
 	elseif IsValid(tr.Entity) and EntityFilter(tr.Entity) and (not bone or aimedbone ~= bone or tr.Entity ~= pl.rgm.Entity) and not moving then

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -2602,17 +2602,17 @@ local function UpdateManipulationSliders(boneid, ent)
 	Pos1:SetValue(pos[1])
 	Pos2:SetValue(pos[2])
 	Pos3:SetValue(pos[3])
-	Entry1:SetValue(pos[1] .. " " .. pos[2] .. " " .. pos[3])
+	Entry1:SetValue(math.Round(pos[1], 2) .. " " .. math.Round(pos[2], 2) .. " " .. math.Round(pos[3], 2))
 
 	Rot1:SetValue(rot[1])
 	Rot2:SetValue(rot[2])
 	Rot3:SetValue(rot[3])
-	Entry2:SetValue(rot[1] .. " " .. rot[2] .. " " .. rot[3])
+	Entry2:SetValue(math.Round(rot[1], 2) .. " " .. math.Round(rot[2], 2) .. " " .. math.Round(rot[3], 2))
 
 	Scale1:SetValue(scale[1])
 	Scale2:SetValue(scale[2])
 	Scale3:SetValue(scale[3])
-	Entry3:SetValue(scale[1] .. " " .. scale[2] .. " " .. scale[3])
+	Entry3:SetValue(math.Round(scale[1], 2) .. " " .. math.Round(scale[2], 2) .. " " .. math.Round(scale[3], 2))
 
 	ManipSliderUpdating = false
 

--- a/lua/weapons/gmod_tool/stools/ragmover_ikchains.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_ikchains.lua
@@ -285,6 +285,7 @@ function TOOL:LeftClick(tr)
 			self.SelectedHip = nil
 			self.SelectedKneeEnt = nil
 			self.SelectedKnee = nil
+			return true
 		else
 			if SERVER then 
 				rgmSendNotif(RGM_NOTIFY.BAD_ORDER.id, self:GetOwner())

--- a/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
@@ -3,7 +3,21 @@ TOOL.Category = "Poser"
 TOOL.Command = nil
 TOOL.ConfigName = ""
 
+CVMaxPRBones = CreateConVar("sv_ragdollmover_max_prop_ragdoll_bones", 32, FCVAR_ARCHIVE + FCVAR_NOTIFY, "Maximum amount of bones that can be used in single Prop Ragdoll", 0, 4096)
+
+local function ClearPropRagdoll(ent)
+	ent.rgmPRidtoent = nil
+	ent.rgmPRenttoid = nil
+	ent.rgmPRparent = nil
+	duplicator.ClearEntityModifier(ent, "Ragdoll Mover Prop Ragdoll")
+end
+
 if SERVER then
+
+	util.AddNetworkString("rgmprSendConEnts")
+	util.AddNetworkString("rgmprApplySkeleton")
+
+
 	duplicator.RegisterEntityModifier("Ragdoll Mover Prop Ragdoll", function(pl, ent, data)
 
 		ent.rgmPRenttoid = table.Copy(data.enttoid)
@@ -31,6 +45,7 @@ if SERVER then
 			local newdata = {}
 			newdata.enttoid = {}
 			for e, id in pairs(ent.rgmPRenttoid) do
+				if type(e) ~= "Entity" or not IsValid(e) then continue end
 				newdata.enttoid[e:EntIndex()] = id
 			end
 			newdata.idtoent = table.Copy(ent.rgmPRidtoent)
@@ -39,15 +54,68 @@ if SERVER then
 			duplicator.ClearEntityModifier(ent, "Ragdoll Mover Prop Ragdoll")
 			duplicator.StoreEntityModifier(ent, "Ragdoll Mover Prop Ragdoll", newdata)
 
-			for id, e in pairs(ent.rgmPRidtoent) do
+			for e, id in pairs(ent.rgmPRenttoid) do
 				if type(e) ~= "Entity" or (type(e) == "Entity" and not IsValid(e)) then -- if some of those entities don't exist, then we gotta dissolve the "ragdoll"
-					ent.rgmPRidtoent = nil
-					ent.rgmPRenttoid = nil
-					ent.rgmPRparent = nil
-					duplicator.ClearEntityModifier(ent, "Ragdoll Mover Prop Ragdoll")
+					ClearPropRagdoll(ent)
 					break
 				end
 			end
+		end
+	end)
+
+	hook.Add("EntityRemoved", "rgmPropRagdollEntRemoved", function(ent)
+		if ent.rgmPRidtoent then
+			for id, ent in pairs(ent.rgmPRidtoent) do
+				if not IsValid(ent) then continue end
+				ClearPropRagdoll(ent)
+			end
+		end
+	end)
+
+	net.Receive("rgmprApplySkeleton", function(len, pl)
+		local count = net.ReadUInt(13)
+		local ents = {}
+		local fail = false
+
+		for i = 0, count - 1 do
+			ents[i] = {}
+			ents[i].ent = net.ReadEntity()
+			ents[i].id = net.ReadUInt(13)
+			local parent = net.ReadUInt(13)
+			ents[i].parent = parent ~= 4100 and parent or nil
+			if not IsValid(ents[i].ent) or not ents[i].ent:GetClass() == "prop_physics" then
+				fail = true
+			end
+		end
+
+		if fail or count > CVMaxPRBones:GetInt() then return end
+
+		for id, data in pairs(ents) do
+			local ent = data.ent
+
+			if ent.rgmPRidtoent then
+				for id, ent in pairs(ent.rgmPRidtoent) do
+					ClearPropRagdoll(ent)
+				end
+			end
+
+			ent.rgmPRidtoent = {}
+			ent.rgmPRenttoid = {}
+			ent.rgmPRparent = data.parent
+			for id, moredata in pairs(ents) do
+				ent.rgmPRidtoent[moredata.id] = moredata.ent
+				ent.rgmPRenttoid[moredata.ent] = moredata.id
+			end
+
+			local data = {}
+			data.idtoent = table.Copy(ent.rgmPRidtoent)
+			data.enttoid = {}
+			for ent, id in pairs(ent.rgmPRenttoid) do
+				data.enttoid[ent:EntIndex()] = id
+			end
+			data.parent = ent.rgmPRparent
+
+			duplicator.StoreEntityModifier(ent, "Ragdoll Mover Prop Ragdoll", data)
 		end
 	end)
 end
@@ -56,77 +124,509 @@ function TOOL:LeftClick(tr)
 	local stage = self:GetStage()
 	local ent = tr.Entity
 
-	if ent:GetClass() ~= "prop_physics" then return false end
+	return false
+end
 
-	if stage == 0 then
-		ent.rgmPRidtoent = {}
-		ent.rgmPRenttoid = {}
-		ent.rgmPRidtoent[0] = ent
-		ent.rgmPRenttoid[ent] = 0
+function TOOL:RightClick(tr)
+	if SERVER then
+		local ent = tr.Entity
+		local doweusethis = false
+		local conents = {}
+		local count = 0
 
-		self.idtoent = ent.rgmPRidtoent
-		self.enttoid = ent.rgmPRenttoid
-		print("One")
-		self:SetStage(1)
-		return true
-	elseif stage == 1 then
-		if self.enttoid[ent] then return false end
-		self.idtoent[1] = ent
-		self.enttoid[ent] = 1
-
-		ent.rgmPRidtoent = self.idtoent
-		ent.rgmPRenttoid = self.enttoid
-		ent.rgmPRparent = 0
-		print("Two")
-		self:SetStage(2)
-		return true
-	
-	elseif stage == 2 then
-		if self.enttoid[ent] then return false end
-		self.idtoent[2] = ent
-		self.enttoid[ent] = 2
-
-		ent.rgmPRidtoent = self.idtoent
-		ent.rgmPRenttoid = self.enttoid
-		ent.rgmPRparent = 1
-		print("Three")
-		self:SetStage(3)
-		return true
-
-	else
-		if self.enttoid[ent] then return false end
-		self.idtoent[3] = ent
-		self.enttoid[ent] = 3
-
-		ent.rgmPRidtoent = self.idtoent
-		ent.rgmPRenttoid = self.enttoid
-		ent.rgmPRparent = 2
-		print("Four")
-		self:SetStage(0)
-
-		if SERVER then
-			for id, ent in pairs(ent.rgmPRidtoent) do
-				local data = {}
-				data.idtoent = table.Copy(ent.rgmPRidtoent)
-				data.enttoid = {}
-				for e, id in pairs(ent.rgmPRenttoid) do
-					data.enttoid[e:EntIndex()] = id
+		if IsValid(ent) and ent:GetClass("prop_physics") then
+			doweusethis = true
+			local ents = constraint.GetAllConstrainedEntities(ent)
+			for ent, _ in pairs(ents) do
+				if ent:GetClass() == "prop_physics" and not IsValid(ent:GetParent()) then
+					conents[ent] = true
 				end
-				data.parent = ent.rgmPRparent
-				duplicator.StoreEntityModifier(ent, "Ragdoll Mover Prop Ragdoll", data)
+			end
+			for ent, _ in pairs(conents) do
+				count = count + 1
 			end
 		end
-		self.idtoent = nil
-		self.enttoid = nil
 
-		return true
+		net.Start("rgmprSendConEnts")
+		net.WriteBool(doweusethis)
+		if doweusethis then
+			net.WriteUInt(count, 13)
+			for ent, _ in pairs(conents) do
+				net.WriteEntity(ent)
+			end
+		end
+		net.Send(self:GetOwner())
 	end
 
-	return false
+	return true
+end
+
+function TOOL:Reload(tr)
+	local ent = tr.Entity
+	if not IsValid(ent) or not ent.rgmPRidtoent then return false end
+
+	if SERVER then
+		for id, ent in pairs(ent.rgmPRidtoent) do
+			ClearPropRagdoll(ent)
+		end
+	end
+
+	return true
 end
 
 if CLIENT then
 
+local PRUI
+local HoveredEnt
 
+local function RGMCallApplySkeleton()
+	if not PRUI or not PRUI.PRTree or not PRUI.PRTree.Nodes then return end
+	if not next(PRUI.PRTree.Nodes) then return end
+	local tree = PRUI.PRTree
+
+	net.Start("rgmprApplySkeleton")
+		net.WriteUInt(tree.Bones, 13)
+		for id, node in pairs(tree.Nodes) do
+			net.WriteEntity(node.ent)
+			net.WriteUInt(node.id, 13)
+			net.WriteUInt(node.parent or 4100,13)
+		end
+	net.SendToServer()
+end
+
+local function DeleteNodeRecursive(node)
+	if IsValid(node) then
+		node:SetParent(nil)
+		node:Remove()
+		for _, child in ipairs(node:GetChildNodes()) do
+			DeleteNodeRecursive(child)
+		end
+	end
+end
+
+local function FindSelfRecursive(nodestart, nodefind)
+	if nodestart == nodefind then return true end
+
+	for _, node in ipairs(nodestart:GetChildNodes()) do
+		if node == nodefind then return true end
+		if FindSelfRecursive(node, nodefind) then return true end
+	end
+	return false
+end
+
+local function TreeUpdateHBar()
+	local width = 0
+
+	for id, node in pairs(PRUI.PRTree.Nodes) do
+		local labelsize = node.Label:GetTextSize()
+		local curwidth = labelsize + (node.depth * 17)
+		if curwidth > width then
+			width = curwidth
+		end
+	end
+
+	PRUI.PRTree:UpdateWidth(width + 8 + 32 + 16)
+end
+
+local function AddHBar(self) -- There is no horizontal scrollbars in gmod, so I guess we'll override vertical one from GMod
+	self.HBar = vgui.Create("DVScrollBar")
+
+	self.HBar.btnUp.Paint = function(panel, w, h) derma.SkinHook("Paint", "ButtonLeft", panel, w, h) end
+	self.HBar.btnDown.Paint = function(panel, w, h) derma.SkinHook("Paint", "ButtonRight", panel, w, h) end
+
+	self.PanelWidth = 100
+	self.LastWidth = 1
+
+	self.HBar.SetScroll = function(self, scrll)
+		if (not self.Enabled) then self.Scroll = 0 return end
+
+		self.Scroll = math.Clamp( scrll, 0, self.CanvasSize )
+
+		self:InvalidateLayout()
+
+		local func = self:GetParent().OnHScroll
+		if func then
+			func(self:GetParent(), self:GetOffset())
+		end
+	end
+
+	self.HBar.OnMousePressed = function(self)
+		local x, y = self:CursorPos()
+
+		local PageSize = self.BarSize
+
+		if (x > self.btnGrip.x) then
+			self:SetScroll(self:GetScroll() + PageSize)
+		else
+			self:SetScroll(self:GetScroll() - PageSize)
+		end
+	end
+
+	self.HBar.OnCursorMoved = function(self, x, y)
+		if (not self.Enabled) then return end
+		if (not self.Dragging) then return end
+
+		local x, y = self:ScreenToLocal(gui.MouseX(), 0)
+
+		x = x - self.btnUp:GetWide()
+		x = x - self.HoldPos
+
+		local BtnHeight = self:GetTall()
+		if (self:GetHideButtons()) then BtnHeight = 0 end
+
+		local TrackSize = self:GetWide() - BtnHeight * 2 - self.btnGrip:GetWide()
+
+		x = x / TrackSize
+
+		self:SetScroll(x * self.CanvasSize)
+	end
+
+	self.HBar.Grip = function(self)
+		if (!self.Enabled) then return end
+		if (self.BarSize == 0) then return end
+
+		self:MouseCapture(true)
+		self.Dragging = true
+
+		local x, y = self.btnGrip:ScreenToLocal(gui.MouseX(), 0)
+		self.HoldPos = x
+
+		self.btnGrip.Depressed = true
+	end
+
+	self.HBar.PerformLayout = function(self)
+		local Tall = self:GetTall()
+		local BtnHeight = Tall
+		if (self:GetHideButtons()) then BtnHeight = 0 end
+		local Scroll = self:GetScroll() / self.CanvasSize
+		local BarSize = math.max(self:BarScale() * (self:GetWide() - (BtnHeight * 2)), 10)
+		local Track = self:GetWide() - (BtnHeight * 2) - BarSize
+		Track = Track + 1
+
+		Scroll = Scroll * Track
+
+		self.btnGrip:SetPos(BtnHeight + Scroll, 0)
+		self.btnGrip:SetSize(BarSize, Tall)
+
+		if (BtnHeight > 0) then
+			self.btnUp:SetPos(0, 0)
+			self.btnUp:SetSize(BtnHeight, Tall)
+
+			self.btnDown:SetPos(self:GetWide() - BtnHeight, 0)
+			self.btnDown:SetSize(BtnHeight, Tall)
+
+			self.btnUp:SetVisible( true )
+			self.btnDown:SetVisible( true )
+		else
+			self.btnUp:SetVisible( false )
+			self.btnDown:SetVisible( false )
+			self.btnDown:SetSize(BtnHeight, Tall)
+			self.btnUp:SetSize(BtnHeight, Tall)
+		end
+	end
+
+	self.OnVScroll = function(self, iOffset)
+		local x = self.pnlCanvas:GetPos()
+		self.pnlCanvas:SetPos(x, iOffset)
+	end
+
+	self.OnHScroll = function(self, iOffset)
+		local _, y = self.pnlCanvas:GetPos()
+		self.pnlCanvas:SetPos(iOffset, y)
+	end
+
+	self.PerformLayoutInternal = function(self)
+		local HTall, VTall = self:GetTall(), self.pnlCanvas:GetTall()
+		local HWide, VWide = self:GetWide(), self.PanelWidth
+		local XPos, YPos = 0, 0
+
+		self:Rebuild()
+
+		self.VBar:SetUp(self:GetTall(), self.pnlCanvas:GetTall())
+		self.HBar:SetUp(self:GetWide(), self.pnlCanvas:GetWide())
+		YPos = self.VBar:GetOffset()
+		XPos = self.HBar:GetOffset()
+
+		if (self.VBar.Enabled) then VWide = VWide - self.VBar:GetWide() end
+		if (self.HBar.Enabled) then HTall = HTall - self.HBar:GetTall() end
+
+		self.pnlCanvas:SetPos(XPos, YPos)
+		self.pnlCanvas:SetSize(VWide, HTall)
+
+		self:Rebuild()
+
+		if (HWide ~= self.LastWidth) then
+			self.HBar:SetScroll(self.HBar:GetScroll())
+		end
+
+		if (VTall ~= self.pnlCanvas:GetTall()) then
+			self.VBar:SetScroll(self.VBar:GetScroll())
+		end
+
+		self.LastWidth = HWide
+	end
+
+	self.PerformLayout = function(self)
+		self:PerformLayoutInternal()
+	end
+
+	self.UpdateWidth = function(self, newwidth)
+		self.PanelWidth = newwidth
+		self:InvalidateLayout()
+	end
+end
+
+local function CCol(cpanel,text, notexpanded)
+	local cat = vgui.Create("DCollapsibleCategory",cpanel)
+	cat:SetExpanded(1)
+	cat:SetLabel(text)
+	cpanel:AddItem(cat)
+	local col = vgui.Create("DPanelList")
+	col:SetAutoSize(true)
+	col:SetSpacing(5)
+	col:EnableHorizontal(false)
+	col:EnableVerticalScrollbar(true)
+	col.Paint = function()
+		surface.DrawRect(0, 0, 500, 500)
+	end
+	cat:SetContents(col)
+	cat:SetExpanded(not notexpanded)
+	return col, cat
+end
+local function AddPRNode(parent, node)
+	HoveredEnt = nil
+
+	if node.used then return end
+	if not PRUI then return end
+	local bones = PRUI.PRTree.Bones
+
+	if bones + 1 > CVMaxPRBones:GetInt() then return end
+	local id = 0
+	while PRUI.PRTree.Nodes[id] do
+		id = id + 1
+	end
+
+	PRUI.PRTree.Nodes[id] = parent:AddNode(id .. " [" .. node.text .. "]", "icon16/brick.png")
+	PRUI.PRTree.Nodes[id].ent = node.ent
+	PRUI.PRTree.Nodes[id].id = id
+	PRUI.PRTree.Nodes[id].parent = parent.id or nil
+	PRUI.PRTree.Nodes[id].depth = parent.depth and parent.depth + 1 or 1
+	PRUI.PRTree.Nodes[id]:Droppable("rgmPRMove")
+
+	PRUI.PRTree.Nodes[id].DoRightClick = function()
+		local deletemenu = DermaMenu(false, PRUI.PRTree)
+
+		local deletebutt = deletemenu:AddOption("Remove from list", function()
+			local parent = PRUI.PRTree.Nodes[id]:GetParent()
+			parent:SetVisible(false)
+			DeleteNodeRecursive(PRUI.PRTree.Nodes[id])
+			if next(parent:GetChildren()) then
+				parent:SetVisible(true)
+			else
+				parent:GetParent().ChildNodes = nil
+			end
+		end)
+		deletebutt:SetIcon("icon16/cross.png")
+
+		deletemenu:Open()
+		return true
+	end
+
+	PRUI.PRTree.Nodes[id]:Receiver("rgmprNew", function(self, received, dropped)
+		PRUI.PRTree:SetSelectedItem(PRUI.PRTree.Nodes[id])
+		if not dropped then return end
+
+		for k, v in ipairs(received) do
+			AddPRNode(PRUI.PRTree.Nodes[id], v)
+		end
+
+	end)
+
+	PRUI.PRTree.Nodes[id]:Receiver("rgmPRMove", function(self, received, dropped)
+		PRUI.PRTree:SetSelectedItem(PRUI.PRTree.Nodes[id])
+		if not dropped then return end
+
+		for k, v in ipairs(received) do
+			if FindSelfRecursive(v, self) then continue end
+			local parent = v:GetParent()
+			parent:SetVisible(false)
+			self:InsertNode(v)
+			v.parent = id
+			v.depth = self.depth + 1
+			if next(parent:GetChildren()) then
+				parent:SetVisible(true)
+			else
+				parent:GetParent().ChildNodes = nil
+			end
+
+			TreeUpdateHBar()
+		end
+	end)
+
+	PRUI.PRTree.Nodes[id].OnRemove = function()
+		if not PRUI.PRTree.Nodes[id] then return end
+		node.used = false
+		node:SetIcon("icon16/brick.png")
+		PRUI.PRTree.Bones = PRUI.PRTree.Bones - 1
+		PRUI.PRTree.Nodes[id] = nil
+	end
+
+	node.used = true
+	node:SetIcon("icon16/delete.png")
+
+	if IsValid(PRUI.PRTree.Nodes[id]:GetParent()) then
+		PRUI.PRTree.Nodes[id]:GetParent():SetVisible(true)
+	end
+
+	PRUI.PRTree.Bones = bones + 1
+
+	TreeUpdateHBar()
+
+end
+
+local function PropRagdollCreator(cpanel)
+
+	local helptext = vgui.Create("DLabel", cpanel)
+	helptext:SetWrap(true)
+	helptext:SetAutoStretchVertical(true)
+	helptext:SetDark(true)
+	helptext:SetText("Drag nodes from Constrained Entities tab into Prop Ragdoll tab to create skeleton for your prop ragdoll and then apply it. This tool can not read Prop Ragdoll skeleton data from existing Prop Ragdolls")
+	cpanel:AddItem(helptext)
+
+	local PropRagdollUI = {}
+	local constrainedents = CCol(cpanel, "Constrained Entities")
+
+	PropRagdollUI.EntTree = vgui.Create("DTree", constrainedents)
+	PropRagdollUI.EntTree:SetTall(300)
+	constrainedents:AddItem(PropRagdollUI.EntTree)
+
+	local creatorpanel = CCol(cpanel, "Prop Ragdoll")
+
+	PropRagdollUI.PRTree = vgui.Create("DTree", creatorpanel)
+	PropRagdollUI.PRTree:SetTall(300)
+	PropRagdollUI.PRTree.Bones = 0
+	PropRagdollUI.PRTree:Receiver("rgmprNew", function(self, received, dropped)
+		if not dropped then return end
+
+		for k, v in ipairs(received) do
+			AddPRNode(PropRagdollUI.PRTree, v)
+		end
+
+	end)
+
+	PropRagdollUI.PRTree:Receiver("rgmPRMove", function(self, received, dropped)
+		if not dropped then return end
+
+		for k, v in ipairs(received) do
+			local parent = v:GetParent()
+			parent:SetVisible(false)
+			self:Root():InsertNode(v)
+			v.parent = nil
+			if next(parent:GetChildren()) then
+				parent:SetVisible(true)
+			else
+				parent:GetParent().ChildNodes = nil
+			end
+
+			TreeUpdateHBar()
+		end
+
+	end)
+
+	AddHBar(PropRagdollUI.PRTree)
+	creatorpanel:AddItem(PropRagdollUI.PRTree)
+	creatorpanel:AddItem(PropRagdollUI.PRTree.HBar)
+
+	local applybutt = vgui.Create("DButton", creatorpanel)
+	applybutt:SetText("Apply Skeleton")
+
+	applybutt.DoClick = RGMCallApplySkeleton
+
+	creatorpanel:AddItem(applybutt)
+
+	return PropRagdollUI
+
+end
+
+local function GetModelName(ent)
+	local name = ent:GetModel()
+	local splitname = string.Split(name, "/")
+	return splitname[#splitname]
+end
+
+local function UpdateConstrainedEnts(ents)
+	if not PRUI then return end
+	PRUI.EntTree:Clear()
+	PRUI.PRTree:Clear()
+	PRUI.EntNodes = {}
+	PRUI.PRTree.Bones = 0
+	PRUI.PRTree.Nodes = {}
+
+	if not next(ents) then return end
+	for _, ent in ipairs(ents) do
+		local text = GetModelName(ent)
+		PRUI.EntNodes[ent] = PRUI.EntTree:AddNode(text, "icon16/brick.png")
+		PRUI.EntNodes[ent]:Droppable("rgmprNew")
+		PRUI.EntNodes[ent].ent = ent
+		PRUI.EntNodes[ent].text = text
+		PRUI.EntNodes[ent].used = false
+
+		PRUI.EntNodes[ent].Label.OnCursorEntered = function()
+			if PRUI.EntNodes[ent].used then return end
+			HoveredEnt = ent
+		end
+
+		PRUI.EntNodes[ent].Label.OnCursorExited = function()
+			HoveredEnt = nil
+		end
+	end
+end
+
+function TOOL.BuildCPanel(CPanel)
+
+	PRUI = PropRagdollCreator(CPanel)
+
+end
+
+local COLOR_RGMGREEN = Color(0,200,0,255)
+
+function TOOL:DrawHUD()
+
+	if PRUI and PRUI.PRTree and PRUI.PRTree.Nodes then
+		for id, node in pairs(PRUI.PRTree.Nodes) do
+			local ent = node.ent
+			local pos = ent:GetPos():ToScreen()
+			local textpos = { x = pos.x+5, y = pos.y-5 }
+			surface.DrawCircle(pos.x, pos.y, 3.5, COLOR_RGMGREEN)
+			draw.SimpleText(node.id,"Default",textpos.x,textpos.y,COLOR_RGMGREEN,TEXT_ALIGN_LEFT,TEXT_ALIGN_BOTTOM)
+
+			if not node.parent then continue end
+			local parent = PRUI.PRTree.Nodes[node.parent].ent
+			local parentpos = parent:GetPos():ToScreen()
+			surface.SetDrawColor(255, 255, 255)
+			surface.DrawLine(pos.x, pos.y, parentpos.x, parentpos.y)
+		end
+	end
+
+	if IsValid(HoveredEnt) then
+		rgm.DrawEntName(HoveredEnt)
+	end
+
+end
+
+net.Receive("rgmprSendConEnts", function(len, pl)
+
+	local validents = net.ReadBool()
+	local ents = {}
+
+	if validents then
+		local count = net.ReadUInt(13)
+		for i = 1, count do
+			ents[i] = net.ReadEntity()
+		end
+	end
+
+	UpdateConstrainedEnts(ents)
+end)
 
 end

--- a/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
@@ -1,0 +1,132 @@
+TOOL.Name = "#tool.ragmover_propragdoll.name2"
+TOOL.Category = "Poser"
+TOOL.Command = nil
+TOOL.ConfigName = ""
+
+if SERVER then
+	duplicator.RegisterEntityModifier("Ragdoll Mover Prop Ragdoll", function(pl, ent, data)
+
+		ent.rgmPRenttoid = table.Copy(data.enttoid)
+		ent.rgmPRidtoent = table.Copy(data.idtoent)
+		ent.rgmPRparent = data.parent
+
+		ent.rgmOldPostEntityPaste = ent.PostEntityPaste
+
+		ent.PostEntityPaste = function(self, pl, ent, crtEnts)
+			if ent.rgmOldPostEntityPaste then
+				ent:rgmOldPostEntityPaste(pl, ent, crtEnts)
+			end
+
+			if not ent.rgmPRenttoid or not ent.rgmPRidtoent then return end
+
+			for oldent, newent in pairs(crtEnts) do
+				local id = ent.rgmPRenttoid[oldent]
+				if not id then continue end
+
+				ent.rgmPRidtoent[id] = newent
+				ent.rgmPRenttoid[oldent] = nil
+				ent.rgmPRenttoid[newent] = id
+			end
+
+			local newdata = {}
+			newdata.enttoid = {}
+			for e, id in pairs(ent.rgmPRenttoid) do
+				newdata.enttoid[e:EntIndex()] = id
+			end
+			newdata.idtoent = table.Copy(ent.rgmPRidtoent)
+			newdata.parent = ent.rgmPRparent
+
+			duplicator.ClearEntityModifier(ent, "Ragdoll Mover Prop Ragdoll")
+			duplicator.StoreEntityModifier(ent, "Ragdoll Mover Prop Ragdoll", newdata)
+
+			for id, e in pairs(ent.rgmPRidtoent) do
+				if type(e) ~= "Entity" or (type(e) == "Entity" and not IsValid(e)) then -- if some of those entities don't exist, then we gotta dissolve the "ragdoll"
+					ent.rgmPRidtoent = nil
+					ent.rgmPRenttoid = nil
+					ent.rgmPRparent = nil
+					duplicator.ClearEntityModifier(ent, "Ragdoll Mover Prop Ragdoll")
+					break
+				end
+			end
+		end
+	end)
+end
+
+function TOOL:LeftClick(tr)
+	local stage = self:GetStage()
+	local ent = tr.Entity
+
+	if ent:GetClass() ~= "prop_physics" then return false end
+
+	if stage == 0 then
+		ent.rgmPRidtoent = {}
+		ent.rgmPRenttoid = {}
+		ent.rgmPRidtoent[0] = ent
+		ent.rgmPRenttoid[ent] = 0
+
+		self.idtoent = ent.rgmPRidtoent
+		self.enttoid = ent.rgmPRenttoid
+		print("One")
+		self:SetStage(1)
+		return true
+	elseif stage == 1 then
+		if self.enttoid[ent] then return false end
+		self.idtoent[1] = ent
+		self.enttoid[ent] = 1
+
+		ent.rgmPRidtoent = self.idtoent
+		ent.rgmPRenttoid = self.enttoid
+		ent.rgmPRparent = 0
+		print("Two")
+		self:SetStage(2)
+		return true
+	
+	elseif stage == 2 then
+		if self.enttoid[ent] then return false end
+		self.idtoent[2] = ent
+		self.enttoid[ent] = 2
+
+		ent.rgmPRidtoent = self.idtoent
+		ent.rgmPRenttoid = self.enttoid
+		ent.rgmPRparent = 1
+		print("Three")
+		self:SetStage(3)
+		return true
+
+	else
+		if self.enttoid[ent] then return false end
+		self.idtoent[3] = ent
+		self.enttoid[ent] = 3
+
+		ent.rgmPRidtoent = self.idtoent
+		ent.rgmPRenttoid = self.enttoid
+		ent.rgmPRparent = 2
+		print("Four")
+		self:SetStage(0)
+
+		if SERVER then
+			for id, ent in pairs(ent.rgmPRidtoent) do
+				local data = {}
+				data.idtoent = table.Copy(ent.rgmPRidtoent)
+				data.enttoid = {}
+				for e, id in pairs(ent.rgmPRenttoid) do
+					data.enttoid[e:EntIndex()] = id
+				end
+				data.parent = ent.rgmPRparent
+				duplicator.StoreEntityModifier(ent, "Ragdoll Mover Prop Ragdoll", data)
+			end
+		end
+		self.idtoent = nil
+		self.enttoid = nil
+
+		return true
+	end
+
+	return false
+end
+
+if CLIENT then
+
+
+
+end

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -148,3 +148,6 @@ tool.ragmover_ikchains.hip=Hip
 tool.ragmover_ikchains.upperarm=Upperarm
 tool.ragmover_ikchains.knee=Knee
 tool.ragmover_ikchains.elbow=Elbow
+
+tool.ragmover_propragdoll.name=Ragdoll Mover - Prop Ragdoll
+tool.ragmover_propragdoll.name2=Rag Mover - Prop Ragdoll

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -149,5 +149,6 @@ tool.ragmover_ikchains.upperarm=Upperarm
 tool.ragmover_ikchains.knee=Knee
 tool.ragmover_ikchains.elbow=Elbow
 
+
 tool.ragmover_propragdoll.name=Ragdoll Mover - Prop Ragdoll
 tool.ragmover_propragdoll.name2=Rag Mover - Prop Ragdoll

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -152,3 +152,19 @@ tool.ragmover_ikchains.elbow=Elbow
 
 tool.ragmover_propragdoll.name=Ragdoll Mover - Prop Ragdoll
 tool.ragmover_propragdoll.name2=Rag Mover - Prop Ragdoll
+tool.ragmover_propragdoll.desc=Create a "Ragdoll" out of props for Ragdoll Mover to work with
+
+tool.ragmover_propragdoll.right=Select physics props and their constrained props
+tool.ragmover_propragdoll.reload=Remove Prop Ragdoll Data
+
+tool.ragmover_propragdoll.treeinfo=Drag nodes from Constrained Entities tab into Prop Ragdoll tab to create skeleton for your prop ragdoll and then apply it. This tool can not read Prop Ragdoll skeleton data from existing Prop Ragdolls
+tool.ragmover_propragdoll.conents=Constrained Entities
+tool.ragmover_propragdoll.propragdoll=Prop Ragdoll
+tool.ragmover_propragdoll.apply=Apply Skeleton
+
+tool.ragmover_propragdoll.message0=Entities selected!
+tool.ragmover_propragdoll.message1=Selection cleared!
+tool.ragmover_propragdoll.message2=Prop Ragdoll skeleton created!
+tool.ragmover_propragdoll.message3=Couldn't apply Prop Ragdoll skeleton. Something must be wrong with the props.
+tool.ragmover_propragdoll.message4=Too many bones in a skeleton!
+tool.ragmover_propragdoll.message5=Prop Ragdoll skeleton data cleared!


### PR DESCRIPTION
Added experimental new tool - Prop ragdoll, which allows to trick ragdoll mover into treating set of connected props as a single ragdoll along with all functions ragdoll mover provides, IKs included!

Reworked ragdoll mover and IK chains tool to work with these prop ragdolls

Optimized net messages a bit

Made it so getting updates for bone manipulation sliders would not trigger their net messages to the server

Ragdoll mover's constrained entities tab will now ignore parented entities

Ragdoll mover's IK Chain tool can save IKs for prop ragdolls

Removed check in ragdoll mover that was meant to prevent gmod crashes from INF and NaN decimals which I did to fix prop ragdolls sometimes not moving some props at all. I didn't crash my gmod yet, although that would needed to be checked out some more - although probably that check was put in place long time ago, gmod might've been updated to fix these things, yet the check stayed.

IK chains tool will now shoot when assigning foot

Nonphysbone manipulation tab now has text entry fields from which you can copypaste parameters

Fixed tracking angles for nonphysical bones

Positioning and scale gizmos should now account for nonphysical angles being rotated, so they should move/resize stuff as expected

Nonphysical bone manipulation tab will now hide position/angle sliders for any physical bones rather than for just physical bones of ragdolls

Fixed issues related to rotating nonphysical bones with rotation gizmos

Fixed issue with gizmo offset breaking bone resetting

Gizmo offsets should now work properly for root bones of parented entities

Fixed the tool breaking when using constrained entity locking

Optimized the list of ignored entities for shift-trace

Now shift-trace will also ignore locked constrained entities

Fixed issue with rounding nonphysical bone parameters after manipulating them with gizmos

Fixed an issue with positioning arrows being weird due to always rotating towards the player

Angle snapping should work somewhat better now, although at 180 degree stuff it may still get weird, so I'd suggest to just use 90 degrees rotations 2 times

Positioning gizmos now support world alignment for nonphysical bones