### PR TITLE
Fixes + Advanced Bonemerge compatibility

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -684,11 +684,13 @@ function SetOffsets(tool, ent, ostable, sbone, rlocks, plocks, nphysinfo)
 	return RTable
 end
 
-local function RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, bone, scale, scalechildren, nphysinfo)
+local function RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, bone, scale, scalechildren, nphysinfo, childrenbones)
 
+	local npbone = ent:TranslatePhysBoneToBone(bone)
+	local npparent = ent:GetBoneParent(npbone)
 	local parent = ostable[bone].parent
 	local nphys = nil
-	if not RTable[parent] then RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, parent, scale, scalechildren, nphysinfo) end
+	if not RTable[parent] then RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, parent, scale, scalechildren, nphysinfo, childrenbones) end
 
 	local ppos, pang = RTable[parent].pos, RTable[parent].ang
 	local bsc = RTable[parent].sc
@@ -705,7 +707,7 @@ local function RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, bo
 		else
 			scaleorig = -2
 		end
-		sc = (ent:GetBoneParent(ent:TranslatePhysBoneToBone(bone)) == scaleorig) and scale or VECTOR_ONE
+		sc = (npparent == scaleorig) and scale or VECTOR_ONE
 	end
 
 	if ostable[bone].nphysbone then
@@ -714,7 +716,12 @@ local function RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, bo
 		bsc = scale
 	end
 
-	pos, ang = LocalToWorld(ostable[bone].pos * sc, ostable[bone].ang, ppos, pang)
+	if childrenbones and childrenbones[npparent] and childrenbones[npparent][npbone] and childrenbones[npparent][npbone].wpos then
+		pos, ang = LocalToWorld(ostable[bone].pos, ostable[bone].ang, ppos, pang)
+		pos = childrenbones[npparent][npbone].wpos
+	else
+		pos, ang = LocalToWorld(ostable[bone].pos * sc, ostable[bone].ang, ppos, pang)
+	end
 
 	if bone == sbone.b then
 		bsc = scale
@@ -724,7 +731,7 @@ local function RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, bo
 		if plocks[ent] and IsValid(plocks[ent][bone]) then
 			pos = plocks[ent][bone]:GetPos()
 		end
-		if slocks[ent] and slocks[ent][ent:TranslatePhysBoneToBone(bone)] then
+		if slocks[ent] and slocks[ent][npbone] then
 			bsc = VECTOR_ONE
 		end
 	end
@@ -734,7 +741,7 @@ local function RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, bo
 	RTable[bone].sc = bsc
 end
 
-function SetScaleOffsets(tool, ent, ostable, sbone, scale, plocks, slocks, scalechildren, nphysinfo)
+function SetScaleOffsets(tool, ent, ostable, sbone, scale, plocks, slocks, scalechildren, nphysinfo, childrenbones)
 	local RTable = {}
 
 	local physcount = ent:GetPhysicsObjectCount() - 1
@@ -755,7 +762,7 @@ function SetScaleOffsets(tool, ent, ostable, sbone, scale, plocks, slocks, scale
 
 	for pb = 0, physcount do
 		if ostable[pb] and not RTable[pb] then
-			RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, pb, scale, scalechildren, nphysinfo)
+			RecursiveSetScale(ostable, sbone, ent, plocks, slocks, RTable, pb, scale, scalechildren, nphysinfo, childrenbones)
 		end
 	end
 

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -218,7 +218,7 @@ function GetPhysBoneParent(ent, bone)
 			return parent
 		end
 		i = i + 1
-		if i > 512 then
+		if i > 256 then
 			cont = true
 		end
 	end

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -417,6 +417,8 @@ function GetOffsetTable(tool, ent, rotate, bonelocks, entlocks)
 		ent.rgmIKChains[k].thighlength = pos1:Distance(pos2)
 		ent.rgmIKChains[k].shinlength = pos2:Distance(pos3)
 
+		ent.rgmIKChains[k].nphyship = nil
+
 	end
 
 	for lockent, pb in pairs(entlocks) do -- getting offsets from physical entities that are locked to our bones

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -338,7 +338,12 @@ function ENT:Think()
 					end
 				end
 			else
-				ang = self.GizmoAng
+				if pl.rgm.GizmoParentID ~= -1 then
+					local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+					_, ang = LocalToWorld(vector_origin, self.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+				else
+					_, ang = LocalToWorld(vector_origin, self.GizmoAng, ent:GetPos(), ent:GetAngles())
+				end
 
 				local manang = ent:GetManipulateBoneAngles(bone)*1
 				manang:Normalize()
@@ -385,7 +390,12 @@ function ENT:Think()
 				end
 			else
 				if IsValid(ent) then
-					ang = self.GizmoAng
+					if pl.rgm.GizmoParentID ~= -1 then
+						local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+						_, ang = LocalToWorld(vector_origin, self.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+					else
+						_, ang = LocalToWorld(vector_origin, self.GizmoAng, ent:GetPos(), ent:GetAngles())
+					end
 				end
 			end
 		end

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -310,6 +310,15 @@ function ENT:Think()
 				end
 			else
 				_ , ang = ent:GetBonePosition(bone)
+
+				if ent:GetClass() == "prop_physics" then
+					local manang = ent:GetManipulateBoneAngles(bone)
+					manang:Normalize()
+
+					_, ang = LocalToWorld(vector_origin, Angle(0, 0, -manang[3]), vector_origin, ang)
+					_, ang = LocalToWorld(vector_origin, Angle(-manang[1], 0, 0), vector_origin, ang)
+					_, ang = LocalToWorld(vector_origin, Angle(0, -manang[2], 0), vector_origin, ang)
+				end
 			end
 		elseif scale and self.GizmoAng then
 			if pl.rgm.GizmoParentID then

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -248,7 +248,7 @@ function ENT:Think()
 	local scale = pl.rgm.Scale or false
 	local offset, offsetlocal = pl.rgm.GizmoOffset, self.localoffset
 
-	if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not (ent:GetClass() == "prop_ragdoll") then
+	if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll") then
 		pos = ent:GetParent():LocalToWorld(ent:GetLocalPos())
 	elseif pl.rgm.IsPhysBone then
 
@@ -278,7 +278,7 @@ function ENT:Think()
 			
 		end
 	end
-	if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not (ent:GetClass() == "prop_ragdoll") and not scale then
+	if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll") and not scale then
 		ang = ent:GetParent():LocalToWorldAngles(ent:GetLocalAngles())
 	elseif pl.rgm.IsPhysBone and not scale then
 
@@ -354,7 +354,7 @@ function ENT:Think()
 		end
 
 		if offsetlocal then 
-			if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not (ent:GetClass() == "prop_ragdoll") then
+			if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll") then
 				self:SetPos(LocalToWorld(offset + entoffset, angle_zero, pos, ent:GetParent():LocalToWorldAngles(ent:GetLocalAngles())))
 			else
 				if pl.rgm.IsPhysBone then

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -229,8 +229,15 @@ function ENT:Think()
 	local ent = pl.rgm.Entity
 	local bone = pl.rgm.PhysBone
 	if not IsValid(ent) or not pl.rgm.Bone or not self.Axises then return end
+	local parent = ent:GetParent()
 
 	if pl.rgm.GizmoParentID and pl.rgm.GizmoParentID ~= -1 and pl.rgm.GizmoParent then
+		local ent = ent
+		if self.EntAdvMerged then
+			if not IsValid(parent) then return end
+			ent = parent
+			if ent.AttachedEntity then ent = ent.AttachedEntity end
+		end
 		local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
 		if physobj then
 			_, self.GizmoParent = LocalToWorld(vector_origin, pl.rgm.GizmoParent, physobj:GetPos(), physobj:GetAngles())
@@ -243,13 +250,18 @@ function ENT:Think()
 		self.GizmoParent = angle_zero
 	end
 
+	local advbones = nil
+	if ent:GetClass() == "ent_advbonemerge" then
+		advbones = ent.AdvBone_BoneInfo
+	end
+
 	local pos, ang
 	local rotate = pl.rgm.Rotate or false
 	local scale = pl.rgm.Scale or false
 	local offset, offsetlocal = pl.rgm.GizmoOffset, self.localoffset
 
-	if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll") then
-		pos = ent:GetParent():LocalToWorld(ent:GetLocalPos())
+	if IsValid(parent) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll") then
+		pos = parent:LocalToWorld(ent:GetLocalPos())
 	elseif pl.rgm.IsPhysBone then
 
 		local physobj = ent:GetPhysicsObjectNum(bone)
@@ -258,14 +270,20 @@ function ENT:Think()
 
 	else
 		bone = pl.rgm.Bone
-		if not self.GizmoPos then
-			local matrix = ent:GetBoneMatrix(bone)
-			pos = ent:GetBonePosition(bone)
-			if pos == ent:GetPos() then
-				pos = matrix:GetTranslation()
-			end
+		if not self.GizmoPos or not self.GizmoAng then
+			return
 		else
-			if pl.rgm.GizmoParentID then
+			if self.EntAdvMerged then
+				local parent = parent
+				if parent.AttachedEntity then parent = parent.AttachedEntity end
+
+				if pl.rgm.GizmoParentID ~= -1 then
+					local physobj = parent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+					pos = LocalToWorld(self.GizmoPos, self.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+				else
+					pos = LocalToWorld(self.GizmoPos, self.GizmoAng, parent:GetPos(), parent:GetAngles())
+				end
+			elseif pl.rgm.GizmoParentID then
 				if pl.rgm.GizmoParentID ~= -1 then
 					local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
 					pos = LocalToWorld(self.GizmoPos, self.GizmoAng, physobj:GetPos(), physobj:GetAngles())
@@ -278,8 +296,10 @@ function ENT:Think()
 			
 		end
 	end
-	if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll") and not scale then
-		ang = ent:GetParent():LocalToWorldAngles(ent:GetLocalAngles())
+
+
+	if IsValid(parent) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll") and not scale then
+		ang = parent:LocalToWorldAngles(ent:GetLocalAngles())
 	elseif pl.rgm.IsPhysBone and not scale then
 
 		local physobj = ent:GetPhysicsObjectNum(bone)
@@ -288,7 +308,16 @@ function ENT:Think()
 
 	else
 		if rotate then
-			if ent:GetBoneParent(bone) ~= -1 then
+			if self.EntAdvMerged then
+				local parent = parent
+				if parent.AttachedEntity then parent = parent.AttachedEntity end
+				if pl.rgm.GizmoParentID ~= -1 then
+					local physobj = parent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+					_, ang = LocalToWorld(vector_origin, self.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+				else
+					_, ang = LocalToWorld(vector_origin, self.GizmoAng, parent:GetPos(), parent:GetAngles())
+				end
+			elseif ent:GetBoneParent(bone) ~= -1 then
 				if not pl.rgm.GizmoParent then -- dunno if there is a need for these failsafes
 					_ , ang = ent:GetBonePosition(bone)
 				else
@@ -299,7 +328,7 @@ function ENT:Think()
 						local _, diff = WorldToLocal(vector_origin, ang, vector_origin, pang)
 						_, ang = LocalToWorld(vector_origin, diff, vector_origin, self.GizmoParent)
 					else
-						local manang = ent:GetManipulateBoneAngles(bone)
+						local manang = ent:GetManipulateBoneAngles(bone)*1
 						manang:Normalize()
 						_, ang = ent:GetBonePosition(bone)
 
@@ -309,30 +338,45 @@ function ENT:Think()
 					end
 				end
 			else
-				_ , ang = ent:GetBonePosition(bone)
+				ang = self.GizmoAng
 
-				if ent:GetClass() == "prop_physics" then
-					local manang = ent:GetManipulateBoneAngles(bone)
-					manang:Normalize()
+				local manang = ent:GetManipulateBoneAngles(bone)*1
+				manang:Normalize()
 
-					_, ang = LocalToWorld(vector_origin, Angle(0, 0, -manang[3]), vector_origin, ang)
-					_, ang = LocalToWorld(vector_origin, Angle(-manang[1], 0, 0), vector_origin, ang)
-					_, ang = LocalToWorld(vector_origin, Angle(0, -manang[2], 0), vector_origin, ang)
-				end
+				_, ang = LocalToWorld(vector_origin, Angle(0, 0, -manang[3]), vector_origin, ang)
+				_, ang = LocalToWorld(vector_origin, Angle(-manang[1], 0, 0), vector_origin, ang)
+				_, ang = LocalToWorld(vector_origin, Angle(0, -manang[2], 0), vector_origin, ang)
 			end
-		elseif scale and self.GizmoAng then
+		elseif scale then
 			if pl.rgm.GizmoParentID then
+				local funent = ent
+				if self.EntAdvMerged then
+					funent = parent
+					if funent.AttachedEntity then funent = funent.AttachedEntity end
+				end
 				if pl.rgm.GizmoParentID ~= -1 then
-					local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+					local physobj = funent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
 					_, ang = LocalToWorld(vector_origin, self.GizmoAng, physobj:GetPos(), physobj:GetAngles())
 				else
-					_, ang = LocalToWorld(vector_origin, self.GizmoAng, ent:GetPos(), ent:GetAngles())
+					_, ang = LocalToWorld(vector_origin, self.GizmoAng, funent:GetPos(), funent:GetAngles())
+				end
+				if self.EntAdvMerged then
+					_, ang = LocalToWorld(vector_origin, ent:GetManipulateBoneAngles(bone), vector_origin, ang)
 				end
 			else
 				ang = self.GizmoAng
 			end
 		else
-			if ent:GetBoneParent(bone) ~= -1 then
+			if self.EntAdvMerged then
+				local parent = parent
+				if parent.AttachedEntity then parent = parent.AttachedEntity end
+				if pl.rgm.GizmoParentID ~= -1 then
+					local physobj = parent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+					_, ang = LocalToWorld(vector_origin, self.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+				else
+					_, ang = LocalToWorld(vector_origin, self.GizmoAng, parent:GetPos(), parent:GetAngles())
+				end
+			elseif ent:GetBoneParent(bone) ~= -1 then
 				if not pl.rgm.GizmoParent then
 					local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone)) -- never would have guessed that when moving bones they use angles of their parent bone rather than their own angles. happened to get to know that after looking at vanilla bone manipulator!
 					ang = matrix:GetAngles()
@@ -341,7 +385,7 @@ function ENT:Think()
 				end
 			else
 				if IsValid(ent) then
-					ang = ent:GetAngles()
+					ang = self.GizmoAng
 				end
 			end
 		end
@@ -354,14 +398,34 @@ function ENT:Think()
 		end
 
 		if offsetlocal then 
-			if IsValid(ent:GetParent()) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll") then
-				self:SetPos(LocalToWorld(offset + entoffset, angle_zero, pos, ent:GetParent():LocalToWorldAngles(ent:GetLocalAngles())))
+			if IsValid(parent) and pl.rgm.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll") then
+				self:SetPos(LocalToWorld(offset + entoffset, angle_zero, pos, parent:LocalToWorldAngles(ent:GetLocalAngles())))
 			else
-				if pl.rgm.IsPhysBone then
+				if self.EntAdvMerged then
+					local funent = parent
+					if funent.AttachedEntity then funent = funent.AttachedEntity end
+					local offsetang
+
+					if pl.rgm.GizmoParentID ~= -1 then
+						local physobj = funent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+						_, offsetang = LocalToWorld(vector_origin, self.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+					else
+						_, offsetang = LocalToWorld(vector_origin, self.GizmoAng, funent:GetPos(), funent:GetAngles())
+					end
+
+					_, offsetang = LocalToWorld(vector_origin, ent:GetManipulateBoneAngles(bone), vector_origin, offsetang)
+
+					self:SetPos(LocalToWorld(offset + entoffset, angle_zero, pos, offsetang))
+				elseif pl.rgm.IsPhysBone then
 					self:SetPos(LocalToWorld(offset + entoffset, angle_zero, pos, ang))
 				else
 					local offsetang
 					if pl.rgm.GizmoParentID then
+						local ent = ent
+						if self.EntAdvMerged then
+							ent = parent
+							if ent.AttachedEntity then ent = ent.AttachedEntity end
+						end
 						if pl.rgm.GizmoParentID ~= -1 then
 							local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
 							_, offsetang = LocalToWorld(vector_origin, self.GizmoAng, physobj:GetPos(), physobj:GetAngles())

--- a/lua/entities/rgm_axis_arrow/init.lua
+++ b/lua/entities/rgm_axis_arrow/init.lua
@@ -5,8 +5,9 @@ AddCSLuaFile("shared.lua")
 
 function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, _, movetype, _, _, nphyspos)
 	local intersect = self:GetGrabPos(eyepos, eyeang, ppos)
-	local localized = self:WorldToLocal(intersect)
 	local axis = self:GetParent()
+	local arrowAng = axis:LocalToWorldAngles(self.DefAngle)
+	local localized = WorldToLocal(intersect, angle_zero, axis:GetPos(), arrowAng)
 	local offset = axis.Owner.rgm.GizmoOffset
 	local entoffset = vector_origin
 	if axis.localoffset then
@@ -24,7 +25,7 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, _, move
 	if movetype == 1 then
 		local obj = ent:GetPhysicsObjectNum(bone)
 		localized = Vector(localized.x, 0, 0)
-		intersect = self:LocalToWorld(localized)
+		intersect = LocalToWorld(localized, angle_zero, axis:GetPos(), arrowAng)
 		ang = obj:GetAngles()
 		pos = LocalToWorld(Vector(offpos.x, 0, 0), angle_zero, intersect - offset, selfangle)
 	elseif movetype == 2 then

--- a/lua/entities/rgm_axis_arrow/init.lua
+++ b/lua/entities/rgm_axis_arrow/init.lua
@@ -6,6 +6,7 @@ AddCSLuaFile("shared.lua")
 function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, _, movetype, _, _, nphyspos)
 	local intersect = self:GetGrabPos(eyepos, eyeang, ppos)
 	local axis = self:GetParent()
+	local parent = ent:GetParent()
 	local arrowAng = axis:LocalToWorldAngles(self.DefAngle)
 	local localized = WorldToLocal(intersect, angle_zero, axis:GetPos(), arrowAng)
 	local offset = axis.Owner.rgm.GizmoOffset
@@ -31,8 +32,30 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, _, move
 	elseif movetype == 2 then
 		local finalpos, boneang
 		local pl = self:GetParent().Owner
+		local advbones = nil
+		if ent:GetClass() == "ent_advbonemerge" then
+			advbones = ent.AdvBone_BoneInfo
+		end
 
-		if ent:GetBoneParent(bone) ~= -1 then
+		if axis.EntAdvMerged then
+			if parent.AttachedEntity then parent = parent.AttachedEntity end
+			local funang
+			if pl.rgm.GizmoParentID ~= -1 then
+				local physobj = parent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+				_, funang = LocalToWorld(vector_origin, axis.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+			else
+				_, funang = LocalToWorld(vector_origin, axis.GizmoAng, parent:GetPos(), parent:GetAngles())
+			end
+
+			local pbone = parent:LookupBone(advbones[bone].parent) -- may need to make an exception if the bone doesn't exist for some reason, but i think adv bonemerge would handle that already
+			local matrix = parent:GetBoneMatrix(pbone)
+			boneang = matrix:GetAngles()
+
+			local _ , pang = parent:GetBonePosition(pbone)
+
+			local _, diff = WorldToLocal(vector_origin, boneang, vector_origin, pang)
+			_, boneang = LocalToWorld(vector_origin, diff, vector_origin, funang)
+		elseif ent:GetBoneParent(bone) ~= -1 then
 			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
 			boneang = matrix:GetAngles()
 			if not (ent:GetClass() == "prop_physics") then
@@ -61,7 +84,7 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, _, move
 		intersect = self:LocalToWorld(localized)
 		ang = ent:GetLocalAngles()
 		pos = LocalToWorld(Vector(offpos.x, 0, 0), angle_zero, intersect - offset, selfangle)
-		pos = ent:GetParent():WorldToLocal(pos)
+		pos = parent:WorldToLocal(pos)
 	end
 	return pos, ang
 end

--- a/lua/entities/rgm_axis_arrow/init.lua
+++ b/lua/entities/rgm_axis_arrow/init.lua
@@ -65,10 +65,15 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, _, move
 				_, boneang = LocalToWorld(vector_origin, diff, vector_origin, axis.GizmoParent)
 			end
 		else
-			if IsValid(ent) then
-				boneang = ent:GetAngles()
+			if ent:GetClass() == "ent_advbonemerge" and parent:GetClass() == "prop_ragdoll" then
+				boneang = angle_zero -- bone has no parent and isn't physical
 			else
-				boneang = angle_zero
+				if pl.rgm.GizmoParentID ~= -1 then
+					local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+					boneang = physobj:GetAngles()
+				else
+					boneang = ent:GetAngles()
+				end
 			end
 		end
 

--- a/lua/entities/rgm_axis_disc/init.lua
+++ b/lua/entities/rgm_axis_disc/init.lua
@@ -25,16 +25,21 @@ function ENT:ProcessMovement(_, offang, eyepos, eyeang, ent, bone, ppos, pnorm, 
 	local intersect = self:GetGrabPos(eyepos, eyeang, ppos, pnorm)
 	local localized = self:WorldToLocal(intersect)
 	local _p, _a
-	local pl = self:GetParent().Owner
+	local axis = self:GetParent()
+	local pl = axis.Owner
+
 	local axistable = {
-		(self:GetParent():LocalToWorld(VECTOR_SIDE) - self:GetPos()):Angle(),
-		(self:GetParent():LocalToWorld(vector_up) - self:GetPos()):Angle(),
-		(self:GetParent():LocalToWorld(VECTOR_FRONT) - self:GetPos()):Angle(),
+		(self:GetParent():LocalToWorld(VECTOR_SIDE) - self:GetPos()):Angle(), --axis:LocalToWorldAngles(axis.DiscP:GetLocalAngles()),
+		(self:GetParent():LocalToWorld(vector_up) - self:GetPos()):Angle(), --axis:LocalToWorldAngles(axis.DiscY:GetLocalAngles()),
+		(self:GetParent():LocalToWorld(VECTOR_FRONT) - self:GetPos()):Angle(), --axis:LocalToWorldAngles(axis.DiscR:GetLocalAngles()),
 		(self:GetPos() - pl:EyePos()):Angle()
 	}
+	axistable[1]:Normalize()
+	axistable[2]:Normalize()
+	axistable[3]:Normalize()
+	axistable[4]:Normalize()
 
 	local mfmod = math.fmod
-	local axis = self:GetParent()
 
 	if movetype == 1 then
 		local offset = axis.Owner.rgm.GizmoOffset
@@ -88,11 +93,20 @@ function ENT:ProcessMovement(_, offang, eyepos, eyeang, ent, bone, ppos, pnorm, 
 		end
 	elseif movetype == 2 then
 		local rotateang, axisangle
+		local parent = ent:GetParent()
 		axisangle = axistable[self.axistype]
 
 		local _, boneang = ent:GetBonePosition(bone)
-		if ent:GetClass() == "prop_physics" then
-			local manang = ent:GetManipulateBoneAngles(bone)
+		if axis.EntAdvMerged then
+			if parent.AttachedEntity then parent = parent.AttachedEntity end
+			if pl.rgm.GizmoParentID ~= -1 then
+				local physobj = parent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+				_, boneang = LocalToWorld(vector_origin, axis.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+			else
+				_, boneang = LocalToWorld(vector_origin, axis.GizmoAng, parent:GetPos(), parent:GetAngles())
+			end
+		elseif ent:GetClass() == "prop_physics" then
+			local manang = ent:GetManipulateBoneAngles(bone)*1
 			manang:Normalize()
 
 			_, boneang = LocalToWorld(vector_origin, Angle(0, 0, -manang[3]), vector_origin, boneang)
@@ -104,6 +118,8 @@ function ENT:ProcessMovement(_, offang, eyepos, eyeang, ent, bone, ppos, pnorm, 
 
 				local _, diff = WorldToLocal(vector_origin, boneang, vector_origin, pang)
 				_, boneang = LocalToWorld(vector_origin, diff, vector_origin, axis.GizmoParent)
+			else
+				boneang = axis.LocalAngles
 			end
 		end
 		local startlocal = LocalToWorld(startangle, startangle:Angle(), vector_origin, axisangle) -- first we get our vectors into world coordinates, relative to the axis angles
@@ -133,6 +149,7 @@ function ENT:ProcessMovement(_, offang, eyepos, eyeang, ent, bone, ppos, pnorm, 
 			_a = rotateang
 		else
 			_a = ent:GetManipulateBoneAngles(bone)
+			_a = _a*1 -- do this to copy angle in case if we're rotating advanced bonemerged stuff
 			rotateang = nphysangle[self.axistype] + rotationangle
 			_a[self.axistype] = rotateang
 		end

--- a/lua/entities/rgm_axis_disc/init.lua
+++ b/lua/entities/rgm_axis_disc/init.lua
@@ -29,9 +29,9 @@ function ENT:ProcessMovement(_, offang, eyepos, eyeang, ent, bone, ppos, pnorm, 
 	local pl = axis.Owner
 
 	local axistable = {
-		(self:GetParent():LocalToWorld(VECTOR_SIDE) - self:GetPos()):Angle(), --axis:LocalToWorldAngles(axis.DiscP:GetLocalAngles()),
-		(self:GetParent():LocalToWorld(vector_up) - self:GetPos()):Angle(), --axis:LocalToWorldAngles(axis.DiscY:GetLocalAngles()),
-		(self:GetParent():LocalToWorld(VECTOR_FRONT) - self:GetPos()):Angle(), --axis:LocalToWorldAngles(axis.DiscR:GetLocalAngles()),
+		(self:GetParent():LocalToWorld(VECTOR_SIDE) - self:GetPos()):Angle(),
+		(self:GetParent():LocalToWorld(vector_up) - self:GetPos()):Angle(),
+		(self:GetParent():LocalToWorld(VECTOR_FRONT) - self:GetPos()):Angle(),
 		(self:GetPos() - pl:EyePos()):Angle()
 	}
 	axistable[1]:Normalize()

--- a/lua/entities/rgm_axis_scale_arrow/init.lua
+++ b/lua/entities/rgm_axis_scale_arrow/init.lua
@@ -9,6 +9,7 @@ function ENT:ProcessMovement(offpos, offang, eyepos, eyeang, ent, bone, ppos, pn
 	local pos, ang
 
 	pos = ent:GetManipulateBoneScale(bone)
+	pos = pos*1 -- multiply by 1 to make a copy of the vector, in case if we scale advanced bonemerged item - those currently use modified ManipulateBoneX functions which seem to cause a bug if I keep altering vector given from GetManipulateBoneX stuff
 	localized = Vector(localized.x - startgrab.x, 0, 0)
 	local posadd = nphysscale[self.axistype] + localized.x
 	ang = ent:GetManipulateBoneAngles(bone)

--- a/lua/entities/rgm_axis_scale_side/init.lua
+++ b/lua/entities/rgm_axis_scale_side/init.lua
@@ -10,7 +10,20 @@ function ENT:ProcessMovement(offpos, offang, eyepos, eyeang, ent, bone, ppos, pn
 	local axis = self:GetParent()
 
 	local localized, finalpos, boneang
-	if ent:GetBoneCount() ~= 0 then
+	if axis.EntAdvMerged then
+		local parent = ent:GetParent()
+		if parent.AttachedEntity then parent = parent.AttachedEntity end
+		local funang
+		if pl.rgm.GizmoParentID ~= -1 then
+			local physobj = parent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+			_, boneang = LocalToWorld(vector_origin, axis.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+		else
+			_, boneang = LocalToWorld(vector_origin, axis.GizmoAng, parent:GetPos(), parent:GetAngles())
+		end
+		if axis.EntAdvMerged then
+			_, boneang = LocalToWorld(vector_origin, ent:GetManipulateBoneAngles(bone), vector_origin, boneang)
+		end
+	elseif ent:GetBoneCount() ~= 0 then
 		if axis.GizmoAng then
 			if pl.rgm.GizmoParentID ~= -1 then
 				local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)

--- a/lua/entities/rgm_axis_side/init.lua
+++ b/lua/entities/rgm_axis_side/init.lua
@@ -6,6 +6,7 @@ AddCSLuaFile("shared.lua")
 function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, movetype, _, _, nphyspos)
 	local intersect = self:GetGrabPos(eyepos, eyeang, ppos, pnorm)
 	local axis = self:GetParent()
+	local parent = ent:GetParent()
 	local offset = axis.Owner.rgm.GizmoOffset
 	local entoffset = vector_origin
 	if axis.localoffset then
@@ -18,7 +19,6 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, 
 		offset = offset + entoffset
 	end
 	local pos, ang
-	local pl = self:GetParent().Owner
 
 	if movetype == 1 then
 		local obj = ent:GetPhysicsObjectNum(bone)
@@ -26,7 +26,31 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, 
 		pos = LocalToWorld(offpos, angle_zero, intersect - offset, self:GetAngles())
 	elseif movetype == 2 then
 		local localized, finalpos, boneang
-		if ent:GetBoneParent(bone) ~= -1 then
+		local advbones = nil
+		if ent:GetClass() == "ent_advbonemerge" then
+			advbones = ent.AdvBone_BoneInfo
+		end
+
+		if axis.EntAdvMerged then
+			if parent.AttachedEntity then parent = parent.AttachedEntity end
+			local pl = self:GetParent().Owner
+			local funang
+			if pl.rgm.GizmoParentID ~= -1 then
+				local physobj = parent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+				_, funang = LocalToWorld(vector_origin, axis.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+			else
+				_, funang = LocalToWorld(vector_origin, axis.GizmoAng, parent:GetPos(), parent:GetAngles())
+			end
+
+			local pbone = parent:LookupBone(advbones[bone].parent) -- may need to make an exception if the bone doesn't exist for some reason, but i think adv bonemerge would handle that already
+			local matrix = parent:GetBoneMatrix(pbone)
+			boneang = matrix:GetAngles()
+
+			local _ , pang = parent:GetBonePosition(pbone)
+
+			local _, diff = WorldToLocal(vector_origin, boneang, vector_origin, pang)
+			_, boneang = LocalToWorld(vector_origin, diff, vector_origin, funang)
+		elseif ent:GetBoneParent(bone) ~= -1 then
 			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
 			boneang = matrix:GetAngles()
 			if not (ent:GetClass() == "prop_physics") then
@@ -52,7 +76,7 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, 
 	elseif movetype == 0 then
 		ang = ent:GetLocalAngles()
 		pos = LocalToWorld(offpos, angle_zero, intersect - offset, self:GetAngles())
-		pos = ent:GetParent():WorldToLocal(pos)
+		pos = parent:WorldToLocal(pos)
 	end
 
 	return pos, ang

--- a/lua/entities/rgm_axis_side/init.lua
+++ b/lua/entities/rgm_axis_side/init.lua
@@ -60,10 +60,16 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, 
 				_, boneang = LocalToWorld(vector_origin, diff, vector_origin, axis.GizmoParent)
 			end
 		else
-			if IsValid(ent) then
-				boneang = ent:GetAngles()
+			if ent:GetClass() == "ent_advbonemerge" and parent:GetClass() == "prop_ragdoll" then
+				boneang = angle_zero -- bone has no parent and isn't physical
 			else
-				boneang = angle_zero
+				local pl = self:GetParent().Owner
+				if pl.rgm.GizmoParentID ~= -1 then
+					local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+					boneang = physobj:GetAngles()
+				else
+					boneang = ent:GetAngles()
+				end
 			end
 		end
 

--- a/lua/entities/rgm_axis_side_omni/init.lua
+++ b/lua/entities/rgm_axis_side_omni/init.lua
@@ -64,10 +64,16 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, 
 				_, boneang = LocalToWorld(vector_origin, diff, vector_origin, axis.GizmoParent)
 			end
 		else
-			if IsValid(ent) then
-				boneang = ent:GetAngles()
+			if ent:GetClass() == "ent_advbonemerge" and parent:GetClass() == "prop_ragdoll" then
+				boneang = angle_zero -- bone has no parent and isn't physical
 			else
-				boneang = angle_zero
+				local pl = self:GetParent().Owner
+				if pl.rgm.GizmoParentID ~= -1 then
+					local physobj = ent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+					boneang = physobj:GetAngles()
+				else
+					boneang = ent:GetAngles()
+				end
 			end
 		end
 

--- a/lua/entities/rgm_axis_side_omni/init.lua
+++ b/lua/entities/rgm_axis_side_omni/init.lua
@@ -10,6 +10,7 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, 
 	end
 
 	local axis = self:GetParent()
+	local parent = ent:GetParent()
 	local offset = axis.Owner.rgm.GizmoOffset
 	local entoffset = vector_origin
 	if axis.localoffset then
@@ -22,7 +23,6 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, 
 		offset = offset + entoffset
 	end
 	local pos, ang
-	local pl = self:GetParent().Owner
 
 	if movetype == 1 then
 		local obj = ent:GetPhysicsObjectNum(bone)
@@ -30,7 +30,31 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, 
 		pos = LocalToWorld(offpos, angle_zero, intersect - offset, self:GetAngles())
 	elseif movetype == 2 then
 		local localized, startmove, finalpos, boneang
-		if ent:GetBoneParent(bone) ~= -1 then
+		local advbones = nil
+		if ent:GetClass() == "ent_advbonemerge" then
+			advbones = ent.AdvBone_BoneInfo
+		end
+
+		if axis.EntAdvMerged then
+			if parent.AttachedEntity then parent = parent.AttachedEntity end
+			local pl = self:GetParent().Owner
+			local funang
+			if pl.rgm.GizmoParentID ~= -1 then
+				local physobj = parent:GetPhysicsObjectNum(pl.rgm.GizmoParentID)
+				_, funang = LocalToWorld(vector_origin, axis.GizmoAng, physobj:GetPos(), physobj:GetAngles())
+			else
+				_, funang = LocalToWorld(vector_origin, axis.GizmoAng, parent:GetPos(), parent:GetAngles())
+			end
+
+			local pbone = parent:LookupBone(advbones[bone].parent) -- may need to make an exception if the bone doesn't exist for some reason, but i think adv bonemerge would handle that already
+			local matrix = parent:GetBoneMatrix(pbone)
+			boneang = matrix:GetAngles()
+
+			local _ , pang = parent:GetBonePosition(pbone)
+
+			local _, diff = WorldToLocal(vector_origin, boneang, vector_origin, pang)
+			_, boneang = LocalToWorld(vector_origin, diff, vector_origin, funang)
+		elseif ent:GetBoneParent(bone) ~= -1 then
 			local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
 			boneang = matrix:GetAngles()
 			if not (ent:GetClass() == "prop_physics") then
@@ -56,7 +80,7 @@ function ENT:ProcessMovement(offpos, _, eyepos, eyeang, ent, bone, ppos, pnorm, 
 	elseif movetype == 0 then
 		ang = ent:GetLocalAngles()
 		pos = LocalToWorld(offpos, angle_zero, intersect - offset, self:GetAngles())
-		pos = ent:GetParent():WorldToLocal(pos)
+		pos = parent:WorldToLocal(pos)
 	end
 
 	return pos, ang

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -835,7 +835,7 @@ net.Receive("rgmSendBonePos", function(len, pl)
 	axis.GizmoPos = newpos
 
 	pl.rgm.GizmoPos = newpos - nonpos
-	if not (axis.EntAdvMerged) then
+	if not (axis.EntAdvMerged) and ent:GetClass() then
 		local manang = entog:GetManipulateBoneAngles(boneog)
 		manang:Normalize()
 
@@ -2380,7 +2380,7 @@ local function rgmSendBonePos(pl, ent, boneid)
 					gizmoppos = matrix:GetTranslation()
 					gizmopang = matrix:GetAngles()
 				else
-					gizmoppos = ent:GetPos()
+					gizmoppos = parent:GetPos()
 					gizmopang = ent:GetAngles()
 				end
 			end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -2213,8 +2213,8 @@ local function rgmSendBonePos(pl, ent, boneid)
 			gizmoppos = matrix:GetTranslation()
 			gizmopang = matrix:GetAngles()
 		else
-			gizmoppos = vector_origin
-			gizmopang = angle_zero
+			gizmoppos = ent:GetPos()
+			gizmopang = ent:GetAngles()
 		end
 
 		gizmopos = pos

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -994,10 +994,6 @@ net.Receive("rgmPrepareOffsets", function(len, pl)
 	pl.rgm.NPhysBoneAng = ent:GetManipulateBoneAngles(bone)
 	pl.rgm.NPhysBoneScale = ent:GetManipulateBoneScale(bone)
 
-	if pl.rgm.physmove ~= 0 then
-		
-	end
-
 	if pl.rgm.IsPhysBone then
 		if axis.smovechildren then
 			if _G["physundo"] and _G["physundo"].Create then

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -32,7 +32,8 @@ tool.ragdollmover.ik4=Right Hand IK
 tool.ragdollmover.ik1=Left Leg IK
 tool.ragdollmover.ik2=Right Leg IK
 tool.ragdollmover.ikchain=Chain
-tool.ragdollmover.ikall=Select/Deselect All
+tool.ragdollmover.ikallon=Select All
+tool.ragdollmover.ikalloff=Deselect All
 tool.ragdollmover.additional=Additional IK Chains
 
 tool.ragdollmover.miscpanel=Misc

--- a/resource/localization/ru/ragdollmover_tools.properties
+++ b/resource/localization/ru/ragdollmover_tools.properties
@@ -32,7 +32,8 @@ tool.ragdollmover.ik4=Правая рука
 tool.ragdollmover.ik1=Левая нога
 tool.ragdollmover.ik2=Правая нога
 tool.ragdollmover.ikchain=Цепь
-tool.ragdollmover.ikall=Включить/выключить все
+tool.ragdollmover.ikallon=Включить все
+tool.ragdollmover.ikalloff=Выключить все
 tool.ragdollmover.additional=Дополнительные цепи
 
 tool.ragdollmover.miscpanel=Дополнительно


### PR DESCRIPTION
- Fixed IK rigs error when moving physical bones through nonphysical ones
- Further fix to unexpected movement when grabbing arrows that point upwards
- Changed amount of bones to look through for phys parent lookup function to 256 from 512 (apparently SFM doesn't support over 256 bones either, after consulting the VDC, also I didn't alter UInt net message amount of bits to 9 from 10 to account for that)
- Physbone movement done through nonphysics manipulation tab now is added to Physgun Undo
- Reset all bones in precise nonphysics bone manipulation tab will now actually reset all bones
- Select All in IKs tab now switches its texts depending on whether it'll select all IKs or deselect them
- Added some calculation exceptions for Advanced Bonemerge entities due to them using overriden ManipulateBone functions
- Physbone movement on ragdolls when scaling will now use proper coordinates based on their parent bones, even if that parent is nonphysics bone