### PR TITLE
UI Scaling to screen res

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -1120,8 +1120,20 @@ function AdvBoneSelectRadialRender(ent, bones)
 		draw.NoTexture()
 		surface.DrawPoly(circ)
 
+		local ytextoffset = -14
+		if uiy > (midh + 30) then ytextoffset = 28 end
+
+		local xtextoffset = 0
+		if uix > (midw + 5) then
+			xtextoffset = 20
+		elseif uix < (midw - 5) then
+			xtextoffset = -20
+		else
+			ytextoffset = ytextoffset*1.5
+		end
+
 		surface.DrawCircle(uix, uiy, 3.5, color)
-		draw.SimpleTextOutlined(name, "Default", uix, uiy - 14, color, TEXT_ALIGN_CENTER, TEXT_ALIGN_BOTTOM, OUTLINE_WIDTH, COLOR_RGMBLACK)
+		draw.SimpleTextOutlined(name, "Default", uix + xtextoffset, uiy + ytextoffset, color, TEXT_ALIGN_CENTER, TEXT_ALIGN_BOTTOM, OUTLINE_WIDTH, COLOR_RGMBLACK)
 	end
 end
 

--- a/lua/entities/rgm_axis/cl_init.lua
+++ b/lua/entities/rgm_axis/cl_init.lua
@@ -62,7 +62,7 @@ function ENT:DrawAngleText(axis, hitpos, startAngle)
 
 	local textAngle = mabs(mround((overnine - localized.y) * 100) / 100)
 	local textpos = hitpos:ToScreen()
-	draw.SimpleTextOutlined(textAngle, "HudDefault", textpos.x + 5, textpos.y, COLOR_RGMGREEN, TEXT_ALIGN_LEFT, TEXT_ALIGN_BOTTOM, OUTLINE_WIDTH, COLOR_RGMBLACK)
+	draw.SimpleTextOutlined(textAngle, "RagdollMoverAngleFont", textpos.x + 5, textpos.y, COLOR_RGMGREEN, TEXT_ALIGN_LEFT, TEXT_ALIGN_BOTTOM, OUTLINE_WIDTH, COLOR_RGMBLACK)
 end
 
 function ENT:Draw()

--- a/lua/ragdollmover/constants.lua
+++ b/lua/ragdollmover/constants.lua
@@ -7,4 +7,5 @@ RGM_Constants = {
 	VECTOR_FRONT = Vector(1, 0, 0),
 	VECTOR_LEFT = Vector(0, 1, 0),
 	VECTOR_NEARZERO = Vector(0.01, 0.01, 0.01),
+	FLOAT_1DIVIDE540 = 0.00185185185
 }

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -2383,7 +2383,7 @@ if SERVER then
 
 					if axis.scalerelativemove then
 
-						RecursiveBoneScale = function(ent, bone, scale, diff, ppos, pang, opos, oang, nppos)
+						RecursiveBoneScale = function(ent, bone, scale, diff, ppos, pang, opos, oang, nppos, poschange)
 							if RAGDOLLMOVER[pl].Bone == bone then
 								local oldscale = ent:GetManipulateBoneScale(bone)
 								ent:ManipulateBoneScale(bone, oldscale + scale)
@@ -2469,26 +2469,33 @@ if SERVER then
 							
 							if childbones[bone] then
 								for cbone, tab in pairs(childbones[bone]) do
+									local poschange = poschange
 									local pos = tab.pos
 									local wpos, wang = LocalToWorld(tab.pos, tab.ang, ppos, pang)
 									local scale = scale
-									if noscale[ent][cbone] then 
-										scale = vector_origin
-									end
 
 									local nwpos
 
-									local lpos = WorldToLocal(wpos, angle_zero, opos, oang)
-									local newpos = lpos*1
+									if not poschange then
+										local lpos = WorldToLocal(wpos, angle_zero, opos, oang)
+										local newpos = lpos*1
 
-									local pscale = ent:GetManipulateBoneScale(RAGDOLLMOVER[pl].Bone) - scale
-									newpos.x, newpos.y, newpos.z = newpos.x / pscale.x, newpos.y / pscale.y, newpos.z / pscale.z
+										local pscale = ent:GetManipulateBoneScale(RAGDOLLMOVER[pl].Bone) - scale
+										newpos.x, newpos.y, newpos.z = newpos.x / pscale.x, newpos.y / pscale.y, newpos.z / pscale.z
 
-									pscale = pscale + scale
-									newpos.x, newpos.y, newpos.z = newpos.x * pscale.x, newpos.y * pscale.y, newpos.z * pscale.z
+										pscale = pscale + scale
+										newpos.x, newpos.y, newpos.z = newpos.x * pscale.x, newpos.y * pscale.y, newpos.z * pscale.z
 
-									nwpos = LocalToWorld(newpos, angle_zero, opos, oang)
+										nwpos = LocalToWorld(newpos, angle_zero, opos, oang)
+									else
+										nwpos = wpos + poschange
+									end
 									tab.wpos = nwpos
+
+									if noscale[ent][cbone] then 
+										scale = vector_origin
+										poschange = nwpos - wpos
+									end
 
 									local bscale1, bscale2, bscale3 = VECTOR_FRONT, VECTOR_LEFT, vector_up
 									local bigvec = nil
@@ -2538,7 +2545,7 @@ if SERVER then
 									ent:ManipulateBonePosition(cbone, bonepos + (newpos - pos))
 									tab.pos = newpos
 
-									RecursiveBoneScale(ent, cbone, scale, diff, wpos, wang, opos, oang, nwpos)
+									RecursiveBoneScale(ent, cbone, scale, diff, wpos, wang, opos, oang, nwpos, poschange)
 								end
 							end
 						end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -2743,7 +2743,7 @@ end)
 
 hook.Add("KeyPress", "rgmSwitchSelectionMode", function(pl, key)
 	local tool = pl:GetTool()
-	if RAGDOLLMOVER[pl] and pl:GetActiveWeapon():GetClass() == "gmod_tool" and tool and tool.Mode == "ragdollmover" then
+	if RAGDOLLMOVER[pl] and IsValid(pl:GetActiveWeapon()) and  pl:GetActiveWeapon():GetClass() == "gmod_tool" and tool and tool.Mode == "ragdollmover" then
 		local op = tool:GetOperation()
 		local opset = 0
 

--- a/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
@@ -958,7 +958,7 @@ function TOOL:DrawHUD()
 			local textpos = { x = pos.x + 5, y = pos.y - 5 }
 			surface.DrawCircle(pos.x, pos.y, 3.5, COLOR_RGMGREEN)
 			if ent ~= HoveredEnt then
-				draw.SimpleTextOutlined(node.id, "Default", textpos.x, textpos.y, COLOR_RGMGREEN, TEXT_ALIGN_LEFT, TEXT_ALIGN_BOTTOM, OUTLINE_WIDTH, COLOR_RGMBLACK)
+				draw.SimpleTextOutlined(node.id, "RagdollMoverFont", textpos.x, textpos.y, COLOR_RGMGREEN, TEXT_ALIGN_LEFT, TEXT_ALIGN_BOTTOM, OUTLINE_WIDTH, COLOR_RGMBLACK)
 			end
 
 			if not node.parent then continue end


### PR DESCRIPTION
- Radial adv bone select now spaces out bones a bit more so it is easier to see them when there's more of them selected, although it gets messy with a lot of bones selected, however that should not be the case in general use
- Locking bone scale should now not prevent movement of bones when using relative scale
- Made adv bone select UI scale with screen resolution, added custom fonts that scale to the screen res on game start
- Fixed error related to pressing any button when dead in multiplayer