### PR TITLE
Relative Scale Adjustment

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -1043,11 +1043,13 @@ end)
 
 function AdvBoneSelectRender(ent, bonenodes)
 	local mx, my = input.GetCursorPos() -- possible bug on mac https://wiki.facepunch.com/gmod/input.GetCursorPos
+	local nodesExist = bonenodes and bonenodes[ent] and true
 
 	local selectedBones = {}
-	for i = 0, ent:GetBoneCount() do
+	for i = 0, ent:GetBoneCount() - 1 do
 		local name = ent:GetBoneName(i)
 		if name == "__INVALIDBONE__" then continue end
+		if nodesExist and (not bonenodes[ent][i]) or false then continue end
 		local pos = ent:GetBonePosition(i)
 		pos = pos:ToScreen()
 
@@ -1063,7 +1065,7 @@ function AdvBoneSelectRender(ent, bonenodes)
 			surface.SetDrawColor(COLOR_BRIGHT_YELLOW:Unpack())
 			table.insert(selectedBones, {name, i})
 		else
-			if bonenodes and bonenodes[ent] and bonenodes[ent][i] and bonenodes[ent][i].Type then
+			if nodesExist and bonenodes[ent][i] and bonenodes[ent][i].Type then
 				surface.SetDrawColor(BONETYPE_COLORS[bonenodes[ent][i].Type]:Unpack())
 			else
 				surface.SetDrawColor(COLOR_RGMGREEN:Unpack())
@@ -1101,7 +1103,7 @@ function AdvBoneSelectRender(ent, bonenodes)
 		end
 
 		local color
-		if bonenodes then
+		if nodesExist then
 			color = BONETYPE_COLORS[bonenodes[ent][selectedBones[i + 1][2]].Type]
 		else
 			color = COLOR_RGMGREEN
@@ -1111,13 +1113,15 @@ function AdvBoneSelectRender(ent, bonenodes)
 	end
 end
 
-function AdvBoneSelectPick(ent)
+function AdvBoneSelectPick(ent, bonenodes)
 	local selected = {}
 	local mx, my = input.GetCursorPos()
+	local nodesExist = bonenodes and bonenodes[ent] and true
 
 	cam.Start3D()
-	for i = 0, ent:GetBoneCount() do
+	for i = 0, ent:GetBoneCount() - 1 do
 		if ent:GetBoneName(i) == "__INVALIDBONE__" then continue end
+		if nodesExist and (not bonenodes[ent][i]) or false then continue end
 
 		local pos = ent:GetBonePosition(i)
 		pos = pos:ToScreen()

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -976,9 +976,12 @@ if CLIENT then
 
 local COLOR_RGMGREEN = RGM_Constants.COLOR_GREEN
 local COLOR_RGMBLACK = RGM_Constants.COLOR_BLACK
+local COLOR_WHITE = RGM_Constants.COLOR_WHITE
+local COLOR_BLUE = RGM_Constants.COLOR_BLUE
+local COLOR_BRIGHT_YELLOW = RGM_Constants.COLOR_BRIGHT_YELLOW
 local OUTLINE_WIDTH = RGM_Constants.OUTLINE_WIDTH
 
-local BONETYPE_COLORS = {RGM_Constants.COLOR_GREEN, RGM_Constants.COLOR_BLUE, RGM_Constants.COLOR_YELLOW, RGM_Constants.COLOR_RED}
+local BONETYPE_COLORS = {RGM_Constants.COLOR_GREEN, RGM_Constants.COLOR_CYAN, RGM_Constants.COLOR_YELLOW, RGM_Constants.COLOR_RED}
 
 function DrawBoneName(ent, bone, name)
 	if not name then
@@ -1053,21 +1056,13 @@ function AdvBoneSelectRender(ent, bonenodes)
 		end
 
 		if dist < 576 then -- 24 pixels
-			surface.SetDrawColor(255, 255, 0, 255)
+			surface.SetDrawColor(COLOR_BRIGHT_YELLOW:Unpack())
 			table.insert(selectedBones, {name, i})
 		else
 			if bonenodes and bonenodes[ent] and bonenodes[ent][i] and bonenodes[ent][i].Type then
-				if bonenodes[ent][i].Type == 1 then	-- physical
-					surface.SetDrawColor(0, 200, 0, 255)
-				elseif bonenodes[ent][i].Type == 2 then -- non physical
-					surface.SetDrawColor(0, 200, 200, 255)
-				elseif bonenodes[ent][i].Type == 3 then -- procedural
-					surface.SetDrawColor(200, 200, 0, 255)
-				elseif bonenodes[ent][i].Type == 4 then -- parented
-					surface.SetDrawColor(200, 0, 0, 255)
-				end
+				surface.SetDrawColor(BONETYPE_COLORS[bonenodes[ent][i].Type]:Unpack())
 			else
-				surface.SetDrawColor(0, 200, 0, 255)
+				surface.SetDrawColor(COLOR_RGMGREEN:Unpack())
 			end
 		end
 
@@ -1132,8 +1127,6 @@ function AdvBoneSelectPick(ent)
 	return selected
 end
 
-local COLOR_WHITE = RGM_Constants.COLOR_WHITE
-local COLOR_BRIGHT_YELLOW = RGM_Constants.COLOR_BRIGHT_YELLOW
 local SelectedBone = nil
 
 function AdvBoneSelectRadialRender(ent, bones, bonenodes)
@@ -1168,22 +1161,14 @@ function AdvBoneSelectRadialRender(ent, bones, bonenodes)
 		end
 
 		if isselected then
-			surface.SetDrawColor(255, 255, 0, 255)
+			surface.SetDrawColor(COLOR_BRIGHT_YELLOW:Unpack())
 			color = COLOR_BRIGHT_YELLOW
 			SelectedBone = bone
 		else
 			if bonenodes and bonenodes[ent] and bonenodes[ent][bone] and bonenodes[ent][bone].Type then
-				if bonenodes[ent][bone].Type == 1 then	-- physical
-					surface.SetDrawColor(0, 200, 0, 255)
-				elseif bonenodes[ent][bone].Type == 2 then -- non physical
-					surface.SetDrawColor(0, 200, 200, 255)
-				elseif bonenodes[ent][bone].Type == 3 then -- procedural
-					surface.SetDrawColor(200, 200, 0, 255)
-				elseif bonenodes[ent][bone].Type == 4 then -- parented
-					surface.SetDrawColor(200, 0, 0, 255)
-				end
+				surface.SetDrawColor(BONETYPE_COLORS[bonenodes[ent][bone].Type]:Unpack())
 			else
-				surface.SetDrawColor(0, 200, 0, 255)
+				surface.SetDrawColor(COLOR_RGMGREEN:Unpack())
 			end
 		end
 
@@ -1219,7 +1204,7 @@ function DrawBoneConnections(ent, bone)
 	end
 	mainpos = mainpos:ToScreen()
 
-	surface.SetDrawColor(0, 200, 0, 255)
+	surface.SetDrawColor(COLOR_RGMGREEN:Unpack())
 	for _, childbone in ipairs(ent:GetChildBones(bone) or {}) do
 		local pos = ent:GetBonePosition(childbone)
 		pos = pos:ToScreen()
@@ -1228,7 +1213,7 @@ function DrawBoneConnections(ent, bone)
 	end
 
 	if ent:GetBoneParent(bone) ~= -1 then
-		surface.SetDrawColor(0, 0, 200, 255)
+		surface.SetDrawColor(COLOR_BLUE:Unpack())
 		local pos = ent:GetBonePosition(ent:GetBoneParent(bone))
 		pos = pos:ToScreen()
 
@@ -1247,7 +1232,7 @@ local function DrawRecursiveBones(ent, bone, bonenodes)
 		local pos = ent:GetBonePosition(boneid)
 		pos = pos:ToScreen()
 
-		surface.SetDrawColor(255, 255, 255, 255)
+		surface.SetDrawColor(COLOR_WHITE:Unpack())
 		surface.DrawLine(mainpos.x, mainpos.y, pos.x, pos.y)
 		DrawRecursiveBones(ent, boneid, bonenodes)
 		local color
@@ -1297,7 +1282,7 @@ function DrawSkeleton(ent, bonenodes)
 
 			local parentpos = ent:GetBonePosition(parent)
 			parentpos = parentpos:ToScreen()
-			surface.SetDrawColor(255, 255, 255, 255)
+			surface.SetDrawColor(COLOR_WHITE:Unpack())
 			surface.DrawLine(parentpos.x, parentpos.y, pos.x, pos.y)
 		end
 

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -60,6 +60,9 @@ function EyePosAng(pl)
 	local viewent = pl:GetViewEntity()
 	if IsValid(viewent) and viewent ~= pl then
 		eyepos = viewent:GetPos()
+		if viewent:GetClass() == "hl_camera" then -- adding support for Advanced Camera's view offset https://steamcommunity.com/sharedfiles/filedetails/?id=881605937&searchtext=advanced+camera
+			eyepos = viewent:LocalToWorld(viewent:GetViewOffset())
+		end
 	end
 	local cursorvec = pl:GetAimVector()
 	--local cursorvec = pl:EyeAngles()

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -55,9 +55,10 @@ local VECTOR_ONE = RGM_Constants.VECTOR_ONE
 
 --Receives player eye position and eye angles.
 --If cursor is visible, eye angles are based on cursor position.
-function EyePosAng(pl)
+function EyePosAng(pl, viewent)
 	local eyepos = pl:EyePos()
-	local viewent = pl:GetViewEntity()
+	if not viewent then viewent = pl:GetViewEntity() end
+
 	if IsValid(viewent) and viewent ~= pl then
 		eyepos = viewent:GetPos()
 		if viewent:GetClass() == "hl_camera" then -- adding support for Advanced Camera's view offset https://steamcommunity.com/sharedfiles/filedetails/?id=881605937&searchtext=advanced+camera

--- a/lua/autorun/ragdollmover_meta.lua
+++ b/lua/autorun/ragdollmover_meta.lua
@@ -31,6 +31,7 @@ hook.Add("PlayerSpawn", "rgmSpawn", function(pl) --PlayerSpawn is a hook that ru
 		RAGDOLLMOVER[pl].Scale = false
 		RAGDOLLMOVER[pl].GizmoOffset = Vector(0, 0, 0)
 		RAGDOLLMOVER[pl].PropRagdoll = false
+		RAGDOLLMOVER[pl].PlViewEnt = 0
 	end
 end)
 

--- a/lua/ragdollmover/constants.lua
+++ b/lua/ragdollmover/constants.lua
@@ -1,6 +1,10 @@
 RGM_Constants = {
+	COLOR_RED = Color(200, 0, 0, 255),
 	COLOR_GREEN = Color(0, 200, 0, 255),
-	COLOR_YELLOW = Color(255, 255, 0, 255),
+	COLOR_BLUE = Color(0, 200, 200, 255), -- it's actually cyan but shhhhh
+	COLOR_YELLOW = Color(200, 200, 0, 255),
+	COLOR_BRIGHT_YELLOW = Color(255, 255, 0, 255),
+	COLOR_WHITE = Color(255, 255, 255, 255),
 	COLOR_BLACK = Color(0, 0, 0, 255),
 	OUTLINE_WIDTH = 1,
 	VECTOR_ONE = Vector(1, 1, 1),

--- a/lua/ragdollmover/constants.lua
+++ b/lua/ragdollmover/constants.lua
@@ -1,7 +1,8 @@
 RGM_Constants = {
 	COLOR_RED = Color(200, 0, 0, 255),
 	COLOR_GREEN = Color(0, 200, 0, 255),
-	COLOR_BLUE = Color(0, 200, 200, 255), -- it's actually cyan but shhhhh
+	COLOR_BLUE = Color(0, 0, 200, 255),
+	COLOR_CYAN = Color(0, 200, 200, 255),
 	COLOR_YELLOW = Color(200, 200, 0, 255),
 	COLOR_BRIGHT_YELLOW = Color(255, 255, 0, 255),
 	COLOR_WHITE = Color(255, 255, 255, 255),

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -2,7 +2,7 @@ RGMGIZMOS = {}
 
 local VECTOR_FRONT = RGM_Constants.VECTOR_FRONT
 local VECTOR_SIDE = RGM_Constants.VECTOR_LEFT
-local COLOR_YELLOW = RGM_Constants.COLOR_YELLOW
+local COLOR_BRIGHT_YELLOW = RGM_Constants.COLOR_BRIGHT_YELLOW
 
 ----------------
 -- BASE GIZMO --
@@ -115,7 +115,7 @@ do
 				local points = self:PointsToWorld(v, scale)
 				local col = color
 				if yellow then
-					col = COLOR_YELLOW
+					col = COLOR_BRIGHT_YELLOW
 				end
 				table.insert(toscreen, {points, col})
 			end
@@ -454,7 +454,7 @@ do
 				local points = self:PointsToWorld(v, scale)
 				local col = color
 				if yellow then
-					col = COLOR_YELLOW
+					col = COLOR_BRIGHT_YELLOW
 				elseif i == 2 then
 					col = color2
 				end
@@ -932,7 +932,7 @@ do
 				local points = self:PointsToWorld(v, scale)
 				local col = color
 				if yellow then
-					col = COLOR_YELLOW
+					col = COLOR_BRIGHT_YELLOW
 				end
 				if parent.fulldisc or (moving or
 				(points[1]:DistToSqr(eyepos) <= borderpos:DistToSqr(eyepos) and points[2]:DistToSqr(eyepos) <= borderpos:DistToSqr(eyepos) and 
@@ -980,7 +980,7 @@ do
 			for i, v in ipairs(linetable) do
 				local col = color
 				if yellow then
-					col = COLOR_YELLOW
+					col = COLOR_BRIGHT_YELLOW
 				end
 				local points = self:PointsToWorld(v, scale * 1.25)
 				table.insert(toscreen, {points, col})

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -151,7 +151,9 @@ do
 	end
 
 	function posarrow:TestCollision(pl, scale)
-		local eyepos, eyeang = rgm.EyePosAng(pl)
+		local plTable = RAGDOLLMOVER[pl]
+		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
+		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
 		local intersect = self:GetGrabPos(eyepos, eyeang)
 		local localized = self:WorldToLocal(intersect)
 		local distmin, distmax
@@ -301,7 +303,9 @@ local posside = table.Copy(basepart)
 do
 
 	function posside:TestCollision(pl, scale)
-		local eyepos, eyeang = rgm.EyePosAng(pl)
+		local plTable = RAGDOLLMOVER[pl]
+		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
+		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
 		local intersect = self:GetGrabPos(eyepos, eyeang)
 		local localized = self:WorldToLocal(intersect)
 		local distmin1, distmax1, distmin2, distmax2
@@ -477,7 +481,9 @@ local omnipos = table.Copy(posside)
 do
 
 	function omnipos:TestCollision(pl, scale)
-		local eyepos, eyeang = rgm.EyePosAng(pl)
+		local plTable = RAGDOLLMOVER[pl]
+		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
+		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
 		local intersect = self:GetGrabPos(eyepos, eyeang)
 		local localized = self:WorldToLocal(intersect)
 		local distmin1, distmax1
@@ -623,7 +629,9 @@ do
 	disc.IsDisc = true
 
 	function disc:TestCollision(pl, scale)
-		local eyepos, eyeang = rgm.EyePosAng(pl)
+		local plTable = RAGDOLLMOVER[pl]
+		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
+		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
 		local intersect = self:GetGrabPos(eyepos, eyeang)
 		local distmin = 0.9 * scale
 		local distmax = 1.1 * scale
@@ -957,7 +965,9 @@ local disclarge = table.Copy(disc)
 do
 
 	function disclarge:TestCollision(pl, scale)
-		local eyepos, eyeang = rgm.EyePosAng(pl)
+		local plTable = RAGDOLLMOVER[pl]
+		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
+		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
 		local intersect = self:GetGrabPos(eyepos, eyeang)
 		local distmin = 1.15 * scale
 		local distmax = 1.35 * scale
@@ -1014,7 +1024,9 @@ do
 	end
 
 	function scalearrow:TestCollision(pl, scale)
-		local eyepos, eyeang = rgm.EyePosAng(pl)
+		local plTable = RAGDOLLMOVER[pl]
+		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
+		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
 		local intersect = self:GetGrabPos(eyepos, eyeang)
 		local localized = self:WorldToLocal(intersect)
 		local distmin, distmax

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1832,6 +1832,21 @@ function TOOL:LeftClick()
 		axis:SetPos(pl:EyePos())
 		axis:Spawn()
 		axis.Owner = pl
+		axis.localpos = self:GetClientNumber("localpos", 0) ~= 0
+		axis.localang = self:GetClientNumber("localang", 1) ~= 0
+		axis.localoffset = self:GetClientNumber("localoffset", 1) ~= 0
+		axis.relativerotate = self:GetClientNumber("relativerotate", 0) ~= 0
+		axis.scalechildren = self:GetClientNumber("scalechildren", 0) ~= 0
+		axis.smovechildren = self:GetClientNumber("smovechildren", 0) ~= 0
+		axis.scalerelativemove = self:GetClientNumber("scalerelativemove", 0) ~= 0
+		RAGDOLLMOVER[pl].Axis = axis
+
+		RAGDOLLMOVER[pl].updaterate = self:GetClientNumber("updaterate", 0.01)
+		RAGDOLLMOVER[pl].unfreeze = self:GetClientNumber("unfreeze", 0)
+		RAGDOLLMOVER[pl].snapenable = self:GetClientNumber("snapenable", 0)
+		RAGDOLLMOVER[pl].snapamount = self:GetClientNumber("snapamount", 30)
+		RAGDOLLMOVER[pl].physmove = self:GetClientNumber("physmove", 0)
+
 		RAGDOLLMOVER[pl].Axis = axis
 
 		RAGDOLLMOVER.Sync(pl, "Axis")

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -241,8 +241,9 @@ local function rgmAdjustScaleTable(parent, childbones, ppos, pang)
 end
 
 local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmove)
+	local plTable = RAGDOLLMOVER[pl]
+
 	if axis.scalechildren and not (ent:GetClass() == "ent_advbonemerge") then
-		local plTable = RAGDOLLMOVER[pl]
 		local scalediff = sc - prevscale
 		local diff
 		local noscale = plTable.rgmScaleLocks

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -4370,6 +4370,17 @@ local NETFUNC = {
 		IsPropRagdoll = false
 		TreeEntities = {}
 		ScaleLocks = {}
+
+		local tool = pl:GetTool()
+		if RAGDOLLMOVER[pl] and IsValid(pl:GetActiveWeapon()) and  pl:GetActiveWeapon():GetClass() == "gmod_tool" and tool and tool.Mode == "ragdollmover" then
+
+			net.Start("RAGDOLLMOVER")
+				net.WriteUInt(14, 5)
+				net.WriteUInt(0, 2)
+			net.SendToServer()
+
+			if tool:GetStage() == 1 then gui.EnableScreenClicker(false) end
+		end
 	end,
 
 	function(len) --					1 - rgmUpdateSliders
@@ -4431,6 +4442,17 @@ local NETFUNC = {
 		if IsValid(ConEntPanel) then
 			RGMBuildConstrainedEnts(selectedent, physchildren, ConEntPanel)
 		end
+
+		local tool = pl:GetTool()
+		if RAGDOLLMOVER[pl] and IsValid(pl:GetActiveWeapon()) and  pl:GetActiveWeapon():GetClass() == "gmod_tool" and tool and tool.Mode == "ragdollmover" then
+
+			net.Start("RAGDOLLMOVER")
+				net.WriteUInt(14, 5)
+				net.WriteUInt(0, 2)
+			net.SendToServer()
+
+			if tool:GetStage() == 1 then gui.EnableScreenClicker(false) end
+		end
 	end,
 
 	function(len) --						3 - rgmUpdateGizmo
@@ -4466,6 +4488,17 @@ local NETFUNC = {
 		end
 		if IsValid(ConEntPanel) then
 			RGMBuildConstrainedEnts(ent, physchildren, ConEntPanel)
+		end
+
+		local tool = pl:GetTool()
+		if RAGDOLLMOVER[pl] and IsValid(pl:GetActiveWeapon()) and  pl:GetActiveWeapon():GetClass() == "gmod_tool" and tool and tool.Mode == "ragdollmover" then
+
+			net.Start("RAGDOLLMOVER")
+				net.WriteUInt(14, 5)
+				net.WriteUInt(0, 2)
+			net.SendToServer()
+
+			if tool:GetStage() == 1 then gui.EnableScreenClicker(false) end
 		end
 	end,
 
@@ -4790,14 +4823,14 @@ function TOOL:DrawHUD()
 	})
 	local aimedbone = IsValid(tr.Entity) and (tr.Entity:GetClass() == "prop_ragdoll" and RAGDOLLMOVER[pl].AimedBone or 0) or 0
 	if IsValid(ent) and EntityFilter(ent, self) and SkeletonDraw then
-		rgm.DrawSkeleton(ent)
+		rgm.DrawSkeleton(ent, nodes)
 	end
 
 	if self:GetOperation() == 2 and IsValid(ent) then
 		if self:GetStage() == 0 then
-			rgm.AdvBoneSelectRender(ent)
+			rgm.AdvBoneSelectRender(ent, nodes)
 		else
-			rgm.AdvBoneSelectRadialRender(ent, RAGDOLLMOVER[pl].SelectedBones)
+			rgm.AdvBoneSelectRadialRender(ent, RAGDOLLMOVER[pl].SelectedBones, nodes)
 		end
 	elseif IsValid(HoveredEntBone) and EntityFilter(HoveredEntBone, self) and HoveredBone then
 		rgm.DrawBoneConnections(HoveredEntBone, HoveredBone)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -242,9 +242,10 @@ end
 
 local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmove)
 	if axis.scalechildren and not (ent:GetClass() == "ent_advbonemerge") then
+		local plTable = RAGDOLLMOVER[pl]
 		local scalediff = sc - prevscale
 		local diff
-		local noscale = RAGDOLLMOVER[pl].rgmScaleLocks
+		local noscale = plTable.rgmScaleLocks
 		local RecursiveBoneScale
 
 		if axis.smovechildren and childbones and childbones[bone] then
@@ -253,12 +254,12 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 			if axis.scalerelativemove then
 
 				RecursiveBoneScale = function(ent, bone, scale, diff, ppos, pang, opos, oang, nppos, poschange)
-					if RAGDOLLMOVER[pl].Bone == bone then
+					if plTable.Bone == bone then
 						local oldscale = ent:GetManipulateBoneScale(bone)
 						ent:ManipulateBoneScale(bone, oldscale + scale)
 
 
-						if RAGDOLLMOVER[pl].IsPhysBone then
+						if plTable.IsPhysBone then
 							local nwpos
 							local lpos = WorldToLocal(ppos, angle_zero, opos, oang)
 							local newpos = lpos*1
@@ -272,7 +273,7 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 							nwpos = LocalToWorld(newpos, angle_zero, opos, oang)
 							local newpos = nwpos - ppos
 
-							local obj = ent:GetPhysicsObjectNum(RAGDOLLMOVER[pl].GizmoParentID)
+							local obj = ent:GetPhysicsObjectNum(plTable.GizmoParentID)
 							obj:EnableMotion(true)
 							obj:Wake()
 							obj:SetPos(obj:GetPos() + newpos)
@@ -284,14 +285,14 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 								offset = LocalToWorld(offset, angle_zero, ppos, angle_zero)
 								offset = WorldToLocal(offset, angle_zero, ppos, pang)
 							end
-							RAGDOLLMOVER[pl].GizmoOffset = RAGDOLLMOVER[pl].GizmoOffset + offset
+							plTable.GizmoOffset = plTable.GizmoOffset + offset
 
 							nppos = nwpos
 						elseif bone ~= 0 then
 							local ang
 
 							if ent:GetBoneParent(bone) ~= -1 then
-								if not RAGDOLLMOVER[pl].GizmoParent then
+								if not plTable.GizmoParent then
 									local matrix = ent:GetBoneMatrix(ent:GetBoneParent(bone))
 									ang = matrix:GetAngles()
 								else
@@ -299,8 +300,8 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 								end
 							else
 								if IsValid(ent) then
-									if RAGDOLLMOVER[pl].GizmoParentID ~= -1 then
-										local physobj = ent:GetPhysicsObjectNum(RAGDOLLMOVER[pl].GizmoParentID)
+									if plTable.GizmoParentID ~= -1 then
+										local physobj = ent:GetPhysicsObjectNum(plTable.GizmoParentID)
 										_, ang = LocalToWorld(vector_origin, axis.GizmoAng, physobj:GetPos(), physobj:GetAngles())
 									else
 										_, ang = LocalToWorld(vector_origin, axis.GizmoAng, ent:GetPos(), ent:GetAngles())
@@ -330,7 +331,7 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 								offset = LocalToWorld(offset, angle_zero, ppos, angle_zero)
 								offset = WorldToLocal(offset, angle_zero, ppos, pang)
 							end
-							RAGDOLLMOVER[pl].GizmoOffset = RAGDOLLMOVER[pl].GizmoOffset + offset
+							plTable.GizmoOffset = plTable.GizmoOffset + offset
 
 							nppos = nwpos
 						end
@@ -349,7 +350,7 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 								local lpos = WorldToLocal(wpos, angle_zero, opos, oang)
 								local newpos = lpos*1
 
-								local pscale = ent:GetManipulateBoneScale(RAGDOLLMOVER[pl].Bone) - scale
+								local pscale = ent:GetManipulateBoneScale(plTable.Bone) - scale
 								newpos.x, newpos.y, newpos.z = newpos.x / pscale.x, newpos.y / pscale.y, newpos.z / pscale.z
 
 								pscale = pscale + scale
@@ -403,7 +404,7 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 			else
 
 				RecursiveBoneScale = function(ent, bone, scale, diff, ppos, pang)
-					if noscale[ent][bone] and not (RAGDOLLMOVER[pl].Bone == bone) then 
+					if noscale[ent][bone] and not (plTable.Bone == bone) then 
 						scale = vector_origin
 						diff = VECTOR_SCALEDEF
 					end
@@ -442,8 +443,8 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 			end
 		end
 
-		if RAGDOLLMOVER[pl].GizmoParentID and RAGDOLLMOVER[pl].GizmoParentID ~= -1 then
-			local obj = ent:GetPhysicsObjectNum(RAGDOLLMOVER[pl].GizmoParentID)
+		if plTable.GizmoParentID and plTable.GizmoParentID ~= -1 then
+			local obj = ent:GetPhysicsObjectNum(plTable.GizmoParentID)
 			if IsValid(obj) then
 				local ppos, pang = obj:GetPos(), obj:GetAngles()
 				ppos, pang = LocalToWorld(axis.GizmoPos, axis.GizmoAng, ppos, pang)
@@ -462,7 +463,7 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 			local ppos, pang
 
 			if ent:GetClass() == "prop_ragdoll" then
-				obj = ent:GetPhysicsObjectNum(RAGDOLLMOVER[pl].GizmoParentID)
+				obj = ent:GetPhysicsObjectNum(plTable.GizmoParentID)
 				if IsValid(obj) then
 					ppos, pang = LocalToWorld(axis.GizmoPos, axis.GizmoAng, obj:GetPos(), obj:GetAngles())
 				end
@@ -486,24 +487,24 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 		ent:ManipulateBoneScale(bone, sc)
 	end
 
-	if ent:GetClass() == "prop_ragdoll" and physmove and (IsValid(ent:GetPhysicsObjectNum(RAGDOLLMOVER[pl].PhysBone)) or IsValid(ent:GetPhysicsObjectNum(RAGDOLLMOVER[pl].NextPhysBone))) and axis.smovechildren then -- moving physical if allowed
-		local pbone = RAGDOLLMOVER[pl].PhysBone
-		local prevscale = RAGDOLLMOVER[pl].NPhysBoneScale
-		if RAGDOLLMOVER[pl].NextPhysBone then
-			pbone = RAGDOLLMOVER[pl].NextPhysBone
+	if ent:GetClass() == "prop_ragdoll" and physmove and (IsValid(ent:GetPhysicsObjectNum(plTable.PhysBone)) or IsValid(ent:GetPhysicsObjectNum(plTable.NextPhysBone))) and axis.smovechildren then -- moving physical if allowed
+		local pbone = plTable.PhysBone
+		local prevscale = plTable.NPhysBoneScale
+		if plTable.NextPhysBone then
+			pbone = plTable.NextPhysBone
 		end
 		local obj = ent:GetPhysicsObjectNum(pbone)
 
 		local p, a = obj:GetPos(), obj:GetAngles()
 		local npos, nang = LocalToWorld(axis.GizmoPos, axis.GizmoAng, p, a)
 		local diff = Vector(sc.x / prevscale.x, sc.y / prevscale.y, sc.z / prevscale.z)
-		local sbone = RAGDOLLMOVER[pl].IsPhysBone and {b = pbone, p = p, a = a} or {}
-		local postable = rgm.SetScaleOffsets(self, ent, RAGDOLLMOVER[pl].rgmOffsetTable, sbone, diff, RAGDOLLMOVER[pl].rgmPosLocks, RAGDOLLMOVER[pl].rgmScaleLocks, axis.scalechildren, {b = RAGDOLLMOVER[pl].Bone, pos = npos, ang = nang}, childbones)
+		local sbone = plTable.IsPhysBone and {b = pbone, p = p, a = a} or {}
+		local postable = rgm.SetScaleOffsets(self, ent, plTable.rgmOffsetTable, sbone, diff, plTable.rgmPosLocks, plTable.rgmScaleLocks, axis.scalechildren, {b = plTable.Bone, pos = npos, ang = nang}, childbones)
 
 		for i = 0, ent:GetPhysicsObjectCount() - 1 do
 			if postable[i] and not postable[i].dontset then
-				local ent = not RAGDOLLMOVER[pl].PropRagdoll and ent or ent.rgmPRidtoent[i]
-				local boneid = not RAGDOLLMOVER[pl].PropRagdoll and i or 0
+				local ent = not plTable.PropRagdoll and ent or ent.rgmPRidtoent[i]
+				local boneid = not plTable.PropRagdoll and i or 0
 				local obj = ent:GetPhysicsObjectNum(boneid)
 
 				obj:EnableMotion(true)
@@ -1234,14 +1235,14 @@ local NETFUNC = {
 				ent = ent:GetParent()
 				if ent.AttachedEntity then ent = ent.AttachedEntity end
 			end
-			if pltable.GizmoParentID ~= -1 then
-				local physobj = ent:GetPhysicsObjectNum(pltable.GizmoParentID)
+			if plTable.GizmoParentID ~= -1 then
+				local physobj = ent:GetPhysicsObjectNum(plTable.GizmoParentID)
 				wpos, wang = LocalToWorld(axis.GizmoPos, axis.GizmoAng, physobj:GetPos(), physobj:GetAngles())
 			else
 				wpos, wang = LocalToWorld(axis.GizmoPos, axis.GizmoAng, ent:GetPos(), ent:GetAngles())
 			end
 		elseif ent:GetClass() == "prop_ragdoll" then
-			ent = ent:GetPhysicsObjectNum(pltable.PhysBone)
+			ent = ent:GetPhysicsObjectNum(plTable.PhysBone)
 			wpos, wang = ent:GetPos(), ent:GetAngles()
 		elseif ent:GetPhysicsObjectCount() == 1 then
 			ent = ent:GetPhysicsObjectNum(0)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1479,46 +1479,27 @@ local NETFUNC = {
 										poschange = nwpos - wpos
 									end
 
-									local bscale1, bscale2, bscale3 = VECTOR_FRONT, VECTOR_LEFT, vector_up
-									local bigvec = nil
+									local refscale = {VECTOR_FRONT, VECTOR_LEFT, vector_up}
+									local nbscale, normscale = {}, {}
 
-									local nbscale1 = LocalToWorld(bscale1, angle_zero, vector_origin, oang) -- there has to be a better way of doing this
-									nbscale1 = WorldToLocal(nbscale1, angle_zero, vector_origin, wang)
-									nbscale1.x = math.abs(nbscale1.x)
-									nbscale1.y = math.abs(nbscale1.y)
-									nbscale1.z = math.abs(nbscale1.z)
-									bigvec = nil
 									for i = 1, 3 do
-										if not bigvec or (nbscale1[i] > nbscale1[bigvec]) then bigvec = i end
+										nbscale[i] = LocalToWorld(refscale[i], angle_zero, vector_origin, oang) -- there has to be a better way of doing this
+										nbscale[i] = WorldToLocal(nbscale[i], angle_zero, vector_origin, wang)
+										nbscale[i].x = math.abs(nbscale[i].x)
+										nbscale[i].y = math.abs(nbscale[i].y)
+										nbscale[i].z = math.abs(nbscale[i].z)
+										normscale[i] = nbscale[i]
+										nbscale[i] = nbscale[i] * scale[i]
 									end
-									nbscale1:Zero()
-									nbscale1[bigvec] = scale.x
+									local normsum = normscale[1] + normscale[2] + normscale[3]
+									normsum.x = 1 / normsum.x
+									normsum.y = 1 / normsum.y
+									normsum.z = 1 / normsum.z
 
-									local nbscale2 = LocalToWorld(bscale2, angle_zero, vector_origin, oang)
-									nbscale2 = WorldToLocal(nbscale2, angle_zero, vector_origin, wang)
-									nbscale2.x = math.abs(nbscale2.x)
-									nbscale2.y = math.abs(nbscale2.y)
-									nbscale2.z = math.abs(nbscale2.z)
-									bigvec = nil
-									for i = 1, 3 do
-										if not bigvec or (nbscale2[i] > nbscale2[bigvec]) then bigvec = i end
-									end
-									nbscale2:Zero()
-									nbscale2[bigvec] = scale.y
-
-									local nbscale3 = LocalToWorld(bscale3, angle_zero, vector_origin, oang)
-									nbscale3 = WorldToLocal(nbscale3, angle_zero, vector_origin, wang)
-									nbscale3.x = math.abs(nbscale3.x)
-									nbscale3.y = math.abs(nbscale3.y)
-									nbscale3.z = math.abs(nbscale3.z)
-									bigvec = nil
-									for i = 1, 3 do
-										if not bigvec or (nbscale3[i] > nbscale3[bigvec]) then bigvec = i end
-									end
-									nbscale3:Zero()
-									nbscale3[bigvec] = scale.z
-
-									local bscale = nbscale1 + nbscale2 + nbscale3
+									local bscale = nbscale[1] + nbscale[2] + nbscale[3]
+									bscale.x = bscale.x * normsum.x
+									bscale.y = bscale.y * normsum.y
+									bscale.z = bscale.z * normsum.z
 
 									ent:ManipulateBoneScale(cbone, ent:GetManipulateBoneScale(cbone) + bscale)
 
@@ -2497,46 +2478,27 @@ if SERVER then
 										poschange = nwpos - wpos
 									end
 
-									local bscale1, bscale2, bscale3 = VECTOR_FRONT, VECTOR_LEFT, vector_up
-									local bigvec = nil
+									local refscale = {VECTOR_FRONT, VECTOR_LEFT, vector_up}
+									local nbscale, normscale = {}, {}
 
-									local nbscale1 = LocalToWorld(bscale1, angle_zero, vector_origin, oang)
-									nbscale1 = WorldToLocal(nbscale1, angle_zero, vector_origin, wang)
-									nbscale1.x = math.abs(nbscale1.x)
-									nbscale1.y = math.abs(nbscale1.y)
-									nbscale1.z = math.abs(nbscale1.z)
-									bigvec = nil
 									for i = 1, 3 do
-										if not bigvec or (nbscale1[i] > nbscale1[bigvec]) then bigvec = i end
+										nbscale[i] = LocalToWorld(refscale[i], angle_zero, vector_origin, oang) -- there has to be a better way of doing this
+										nbscale[i] = WorldToLocal(nbscale[i], angle_zero, vector_origin, wang)
+										nbscale[i].x = math.abs(nbscale[i].x)
+										nbscale[i].y = math.abs(nbscale[i].y)
+										nbscale[i].z = math.abs(nbscale[i].z)
+										normscale[i] = nbscale[i]
+										nbscale[i] = nbscale[i] * scale[i]
 									end
-									nbscale1:Zero()
-									nbscale1[bigvec] = scale.x
+									local normsum = normscale[1] + normscale[2] + normscale[3]
+									normsum.x = 1 / normsum.x
+									normsum.y = 1 / normsum.y
+									normsum.z = 1 / normsum.z
 
-									local nbscale2 = LocalToWorld(bscale2, angle_zero, vector_origin, oang)
-									nbscale2 = WorldToLocal(nbscale2, angle_zero, vector_origin, wang)
-									nbscale2.x = math.abs(nbscale2.x)
-									nbscale2.y = math.abs(nbscale2.y)
-									nbscale2.z = math.abs(nbscale2.z)
-									bigvec = nil
-									for i = 1, 3 do
-										if not bigvec or (nbscale2[i] > nbscale2[bigvec]) then bigvec = i end
-									end
-									nbscale2:Zero()
-									nbscale2[bigvec] = scale.y
-
-									local nbscale3 = LocalToWorld(bscale3, angle_zero, vector_origin, oang)
-									nbscale3 = WorldToLocal(nbscale3, angle_zero, vector_origin, wang)
-									nbscale3.x = math.abs(nbscale3.x)
-									nbscale3.y = math.abs(nbscale3.y)
-									nbscale3.z = math.abs(nbscale3.z)
-									bigvec = nil
-									for i = 1, 3 do
-										if not bigvec or (nbscale3[i] > nbscale3[bigvec]) then bigvec = i end
-									end
-									nbscale3:Zero()
-									nbscale3[bigvec] = scale.z
-
-									local bscale = nbscale1 + nbscale2 + nbscale3
+									local bscale = nbscale[1] + nbscale[2] + nbscale[3]
+									bscale.x = bscale.x * normsum.x
+									bscale.y = bscale.y * normsum.y
+									bscale.z = bscale.z * normsum.z
 
 									ent:ManipulateBoneScale(cbone, ent:GetManipulateBoneScale(cbone) + bscale)
 

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -4451,7 +4451,7 @@ function TOOL:Think()
 
 			if IsValid(ent) then
 				if self:GetStage() ~= 1 then
-					local selbones = rgm.AdvBoneSelectPick(ent)
+					local selbones = rgm.AdvBoneSelectPick(ent, nodes)
 					if next(selbones) then
 						if #selbones == 1 then
 							net.Start("RAGDOLLMOVER")

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -2440,8 +2440,6 @@ end
 
 if CLIENT then
 
-local PlViewVar = GetConVar("ragdollmover_always_use_pl_view")
-
 TOOL.Information = {
 	{ name = "left_advselect", op = 2 },
 	{ name = "info_advselect", op = 2 },

--- a/lua/weapons/gmod_tool/stools/ragmover_ikchains.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_ikchains.lua
@@ -554,7 +554,7 @@ function TOOL.BuildCPanel(CPanel)
 end
 
 local PrevEnt = nil
-local COLOR_GREEN = Color(0, 200, 0, 255)
+local COLOR_GREEN = RGM_Constants.COLOR_GREEN
 local AIMED_SKELETON, AIMED_BONE = nil, nil
 local CHOSEN_HIP, CHOSEN_KNEE = nil, nil
 


### PR DESCRIPTION
- Relative bone scale now has more precise scaling

Unrelated:
- UI now shows bones in different colors, green - physical, cyan - nonphys, yellow - procedural and red for parented
- Fixed some errors related to Adv Bone select
- Added lua file that contains all constants for ragdoll mover like vectors and colors for easier editing them everywhere
- Fixed rgm entity spawning without its convars being set
- Bone scaling functions were moved into a single function
- Fixed setting gizmo offset to bones on nonphys entities
- Some performance improvements
- Moving stuff through camera with RGM now works with advanced camera offset
- Added ragdollmover_always_use_pl_view convar to always use player view when moving stuff, and holding down gizmo will use the view of whatever entity you were using when you started moving it even if you switch view somewhere else
- Bone tree filters now affect bones that Adv Bone Select can work with