### PR TITLE
Make the gizmo update its position when out of bounds

### DIFF
--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -11,12 +11,18 @@ local VECTOR_FRONT = RGM_Constants.VECTOR_FRONT
 local ANGLE_DISC = Angle(0, 90, 0)
 local ANGLE_ARROW_OFFSET = Angle(0, 90, 90)
 
+-- How much player's velocity should influence collision bound
+local PLAYER_WEIGHT = 0.5
+-- How much gizmo's own velocity should influence collision bound
+local GIZMO_WEIGHT = 1000
+
 function ENT:Think()
 	local pl = self.Owner
 	local size = self.DefaultMinMax
 	-- Extend the collision bounds to include us, with some velocity tracking to ensure that the gizmo updates as much as possible outside of the world
 	if not util.IsInWorld(self:GetPos()) then
-		size = (pl:GetPos() - self:GetPos()) * (0.1 * pl:GetVelocity() + (self:GetPos() - self.LastPos) / CurTime()):Length()
+		local velocity = (self:GetPos() - self.LastPos) / CurTime()
+		size = (pl:GetPos() - self:GetPos()) + (PLAYER_WEIGHT * pl:GetVelocity() + GIZMO_WEIGHT * velocity)
 	end
 	-- Only set the collision bounds if it differs from our last size.
 	if self.LastSize ~= size then

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -16,13 +16,14 @@ function ENT:Think()
 	local size = self.DefaultMinMax
 	-- Extend the collision bounds to include us, with some velocity tracking to ensure that the gizmo updates as much as possible outside of the world
 	if not util.IsInWorld(self:GetPos()) then
-		size = (pl:GetPos() - self:GetPos()) * (0.1 * pl:GetVelocity() + 2 * (self:GetPos() - self.LastPos) / CurTime()):Length()
+		size = (pl:GetPos() - self:GetPos()) * (0.1 * pl:GetVelocity() + (self:GetPos() - self.LastPos) / CurTime()):Length()
 	end
 	-- Only set the collision bounds if it differs from our last size.
 	if self.LastSize ~= size then
 		self:SetCollisionBounds(-1 * size, size)
 		self.LastSize = size
 	end
+	self.LastPos = self:GetPos()
 
 	if not IsValid(pl) then return end
 

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -10,7 +10,6 @@ local VECTOR_ORIGIN = vector_origin
 local VECTOR_FRONT = RGM_Constants.VECTOR_FRONT
 local ANGLE_DISC = Angle(0, 90, 0)
 local ANGLE_ARROW_OFFSET = Angle(0, 90, 90)
-local COLOR_RED = Color(255, 0, 0)
 
 function ENT:Think()
 	local pl = self.Owner

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -11,18 +11,20 @@ local VECTOR_FRONT = RGM_Constants.VECTOR_FRONT
 local ANGLE_DISC = Angle(0, 90, 0)
 local ANGLE_ARROW_OFFSET = Angle(0, 90, 90)
 
+-- How much we should try to contain the player and the gizmo
+local DISTANCE_PADDING = 2
 -- How much player's velocity should influence collision bound
-local PLAYER_WEIGHT = 0.5
+local PLAYER_WEIGHT = 0.9
 -- How much gizmo's own velocity should influence collision bound
-local GIZMO_WEIGHT = 1000
+local GIZMO_WEIGHT = 0.1
 
 function ENT:Think()
 	local pl = self.Owner
 	local size = self.DefaultMinMax
 	-- Extend the collision bounds to include us, with some velocity tracking to ensure that the gizmo updates as much as possible outside of the world
 	if not util.IsInWorld(self:GetPos()) then
-		local velocity = (self:GetPos() - self.LastPos) / CurTime()
-		size = 2 * (pl:GetPos() - self:GetPos()) + (PLAYER_WEIGHT * pl:GetVelocity() + GIZMO_WEIGHT * velocity)
+		local velocity = (self:GetPos() - self.LastPos) / FrameTime()
+		size = DISTANCE_PADDING * (pl:GetPos() - self:GetPos()) + (PLAYER_WEIGHT * pl:GetVelocity() + GIZMO_WEIGHT * velocity)
 	end
 	-- Only set the collision bounds if it differs from our last size.
 	if self.LastSize ~= size then

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -22,7 +22,7 @@ function ENT:Think()
 	-- Extend the collision bounds to include us, with some velocity tracking to ensure that the gizmo updates as much as possible outside of the world
 	if not util.IsInWorld(self:GetPos()) then
 		local velocity = (self:GetPos() - self.LastPos) / CurTime()
-		size = (pl:GetPos() - self:GetPos()) + (PLAYER_WEIGHT * pl:GetVelocity() + GIZMO_WEIGHT * velocity)
+		size = 2 * (pl:GetPos() - self:GetPos()) + (PLAYER_WEIGHT * pl:GetVelocity() + GIZMO_WEIGHT * velocity)
 	end
 	-- Only set the collision bounds if it differs from our last size.
 	if self.LastSize ~= size then

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -10,9 +10,21 @@ local VECTOR_ORIGIN = vector_origin
 local VECTOR_FRONT = RGM_Constants.VECTOR_FRONT
 local ANGLE_DISC = Angle(0, 90, 0)
 local ANGLE_ARROW_OFFSET = Angle(0, 90, 90)
+local COLOR_RED = Color(255, 0, 0)
 
 function ENT:Think()
 	local pl = self.Owner
+	local size = self.DefaultMinMax
+	-- Extend the collision bounds to include us, with some velocity tracking to ensure that the gizmo updates as much as possible outside of the world
+	if not util.IsInWorld(self:GetPos()) then
+		size = (pl:GetPos() - self:GetPos()) * (0.1 * pl:GetVelocity() + 2 * (self:GetPos() - self.LastPos) / CurTime()):Length()
+	end
+	-- Only set the collision bounds if it differs from our last size.
+	if self.LastSize ~= size then
+		self:SetCollisionBounds(-1 * size, size)
+		self.LastSize = size
+	end
+
 	if not IsValid(pl) then return end
 
 	local plTable = RAGDOLLMOVER[pl]

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -4,8 +4,12 @@ ENT.Base = "base_entity"
 
 function ENT:Initialize()
 
+	self.DefaultMinMax = Vector(0.1, 0.1, 0.1)
+	self.LastSize = self.DefaultMinMax
+	self.LastPos = self:GetPos()
+
 	self:DrawShadow(false)
-	self:SetCollisionBounds(Vector(-0.1, -0.1, -0.1), Vector(0.1, 0.1, 0.1))
+	self:SetCollisionBounds(-self.DefaultMinMax, self.DefaultMinMax)
 	self:SetSolid(SOLID_VPHYSICS)
 	self:SetNotSolid(true)
 


### PR DESCRIPTION
- We set their collision bounds to contain the player; if the player is in the world, the gizmo will update its position, even if it is out of bounds. This allows the user to still move the gizmo around when it is out of bounds (e.g. using IK chains for foot placement, or for props with visually inconsistent origins)