### PR TITLE
Additional gizmo enhancements (#13)

### DIFF
--- a/lua/autorun/ragdollmover_meta.lua
+++ b/lua/autorun/ragdollmover_meta.lua
@@ -16,6 +16,31 @@ local TYPE_BOOL		 = 5
 
 RAGDOLLMOVER = {}
 
+local shouldCallHook = false
+hook.Add("EntityKeyValue", "RGMAllowTool", function(ent, key, val)
+	-- I couldn't find a clean, direct way to add ragdollmover to the m_tblToolsAllowed for both
+	-- loading into a map or loading a save on the same map.
+	if key == "gmod_allowtools" and not string.find(val, "ragdollmover") then
+		shouldCallHook = true
+	end
+
+	-- We can't call the hook at the same time the key is gmod_allowtools because ent.m_tblToolsAllowed 
+	-- must exist (which relies on the gmod_allowtools key), but it doesn't yet
+	if shouldCallHook and key ~= "gmod_allowtools" then
+		hook.Run("RGMAllowTool", ent)
+		shouldCallHook = false
+	end
+end)
+
+-- Some brush entities only allow a select number of tools (see https://wiki.facepunch.com/gmod/Sandbox_Specific_Mapping)
+-- Without this, the gizmos would not be "selectable"
+hook.Add("RGMAllowTool", "RGMAllowTool", function(ent)
+	-- If the table is not filled, we don't want to insert it, as it would make other tools not work
+	if istable(ent.m_tblToolsAllowed) and #ent.m_tblToolsAllowed > 0 then
+		table.insert(ent.m_tblToolsAllowed, "ragdollmover")
+	end
+end)
+
 if SERVER then
 
 util.AddNetworkString("RAGDOLLMOVER_META")
@@ -42,6 +67,7 @@ hook.Add("PlayerDisconnected", "RGMCleanupGizmos", function(pl)
 	end
 	RAGDOLLMOVER[pl] = nil
 end)
+
 
 local NumpadBindRot, NumpadBindScale = {}, {}
 local RotKey, ScaleKey = {}, {}

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -10,6 +10,7 @@ function ENT:Initialize()
 
 	self:DrawShadow(false)
 	self:SetCollisionBounds(-self.DefaultMinMax, self.DefaultMinMax)
+	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 	self:SetNotSolid(true)
 

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1851,7 +1851,7 @@ function TOOL:Deploy()
 end
 
 local function EntityFilter(ent, tool)
-	return (ent:GetClass() == "prop_ragdoll" or ent:GetClass() == "prop_physics" or ent:GetClass() == "prop_effect") or (tool:GetClientNumber("disablefilter") ~= 0 and not ent:IsWorld())
+	return ent:GetBrushPlaneCount() == 0 and ((ent:GetClass() == "prop_ragdoll" or ent:GetClass() == "prop_physics" or ent:GetClass() == "prop_effect") or (tool:GetClientNumber("disablefilter") ~= 0 and not ent:IsWorld()))
 end
 
 function TOOL:LeftClick()
@@ -2225,7 +2225,7 @@ function TOOL:Reload()
 end
 
 
-function TOOL:Think()
+function TOOL:Think()	
 
 if SERVER then
 
@@ -2235,7 +2235,7 @@ if SERVER then
 	if CurTime() < self.LastThink + (RAGDOLLMOVER[pl].updaterate or 0.01) then return end
 
 	local plTable = RAGDOLLMOVER[pl]
-
+	
 	local ent = plTable.Entity
 	local axis = plTable.Axis
 


### PR DESCRIPTION
* Fix gizmos not catching up to cursor position
+ By default, the rgm_axis is created with MOVETYPE_NONE on the client, which causes the gizmo to delay its movement to the cursor. This fixes it by setting its movetype to MOVETYPE_VPHYSICS, replicating the behavior seen from tool ghost entities.

* Fixed inability to click on gizmos in some environments

* Change behavior for func_brush functionality
+ Added InitPostEntity hook to insert ragdollmover to all func_brush entities with a m_tblToolsAllowed field, which fixes unselectable gizmos in func_brush entities for singleplayer and multiplayer
- Removed rgm_ghost and ghost padding implementations, which has been superseded by the above hook

* Generalize to entities with brush planes instead of strictly func_brush

* Improved appending of ragdollmover to m_tblToolsAllowed
- Changed previous method to target all brush entities with a gmod_allowtools key instead of func_brush alone. This allows Ragdoll Mover to still be used if the brush entity has this key for some reason.

* Move table insert logic into the shared RGMAllowTool hook
- Moved table.insert of ragdollmover tool mode into rgmAllowTool hook
- Changed realm of EntityKeyValue to shared instead of server