### PR TITLE
Use `util.IsPointInCone` instead of `pos.visible` (#14)

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -1120,25 +1120,26 @@ concommand.Add("ragdollmover_changelog", function()
 	showChangelog()
 end)
 
-function AdvBoneSelectRender(ent, bonenodes, prevbones, calc)
+function AdvBoneSelectRender(ent, bonenodes, prevbones, calc, eyePos, eyeVector, fov)
 	local mx, my = input.GetCursorPos() -- possible bug on mac https://wiki.facepunch.com/gmod/input.GetCursorPos
 	local nodesExist = bonenodes and bonenodes[ent] and true
 	local bonedistances = {}
-	local eyeVector = LocalPlayer():GetAimVector()
 	local mindist, maxdist = nil, nil
 
-	if calc then
-		prevbones = {}
+	local fovCosine = math.cos(math.rad(fov * 0.65))
 
+	if calc then
 		for i = 0, ent:GetBoneCount() - 1 do
 			local pos = ent:GetBonePosition(i)
 			local dist = 1000
-			if pos:ToScreen().visible then
+			local result = util.IsPointInCone(pos, eyePos, eyeVector, fovCosine, 131072)
+			if result then
 				dist = eyeVector:Dot( pos )
 				if not mindist or mindist > dist then mindist = dist end
 				if not maxdist or maxdist < dist then maxdist = dist end
 			end
 			bonedistances[i] = dist
+			prevbones[i] = result
 		end
 		-- maxdist or mindist may be nil if we weren't looking at all the bones. 
 		-- We set them to some numbers to avoid issues with indicing with these
@@ -1152,9 +1153,9 @@ function AdvBoneSelectRender(ent, bonenodes, prevbones, calc)
 		local name = ent:GetBoneName(i)
 		if name == "__INVALIDBONE__" then continue end
 		if nodesExist and (not bonenodes[ent][i]) or false then continue end
+		if not prevbones[i] then continue end
 		local pos = ent:GetBonePosition(i)
 		pos = pos:ToScreen()
-		if not pos.visible then continue end
 		local x, y = pos.x, pos.y
 
 		local dist = math.abs((mx - x)^2 + (my - y)^2)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -4892,7 +4892,7 @@ hook.Add("KeyPress", "rgmSwitchSelectionMode", function(pl, key)
 	end
 end)
 
-local BoneColors = nil
+local BoneColors = {}
 local LastSelectThink, LastEnt = 0, nil
 
 function TOOL:DrawHUD()
@@ -4911,6 +4911,8 @@ function TOOL:DrawHUD()
 
 	local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
 	local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
+	local viewvec = IsValid(plviewent) and plviewent:GetForward() or pl:GetViewEntity():GetForward()
+	local fov = pl:GetFOV()
 
 	if not (self:GetOperation() == 2) and IsValid(ent) and IsValid(axis) and bone then
 		local width = GizmoWidth or 0.5
@@ -4955,7 +4957,7 @@ function TOOL:DrawHUD()
 		local calc = ( not LastEnt or LastEnt ~= ent ) or timecheck
 
 		if self:GetStage() == 0 then
-			BoneColors = rgm.AdvBoneSelectRender(ent, nodes, BoneColors, calc)
+			BoneColors = rgm.AdvBoneSelectRender(ent, nodes, BoneColors, calc, eyepos, viewvec, fov)
 		else
 			rgm.AdvBoneSelectRadialRender(ent, plTable.SelectedBones, nodes, ResetMode)
 		end


### PR DESCRIPTION
* Use `util.IsPointInCone` instead of `pos.visible` to restrict edge cases

* Further restrict the view cone angle

* Cache util.IsPointInCone in prevbones[i]; if it exists, we calculate fraction and color
- Also use cached result so we do not have to get bone positions

* Initially set `BoneColors = {}`, so we don't need to do `prevbones = {}` on `calc`

* View entity support for AdvBoneSelectRender

* Opt to use the forward vector of the view entity, instead of cursor vector