### PR TITLE
Spherical Rotation

### DIFF
--- a/lua/entities/rgm_axis/cl_init.lua
+++ b/lua/entities/rgm_axis/cl_init.lua
@@ -15,8 +15,12 @@ local pl
 function ENT:DrawLines(width)
 	if not pl then pl = LocalPlayer() end
 
-	local rotate = RAGDOLLMOVER[pl].Rotate or false
-	local modescale = RAGDOLLMOVER[pl].Scale or false
+	local plTable = RAGDOLLMOVER[pl]
+	local rotate = plTable.Rotate or false
+	local modescale = plTable.Scale or false
+	local ent = plTable.Entity
+	local bone = plTable.Bone
+	local isparentbone = IsValid(ent) and IsValid(ent:GetParent()) and bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll")
 	local scale = self.scale
 	local start, last = 1, 7
 	if rotate then start, last = 8, 12 end
@@ -27,11 +31,11 @@ function ENT:DrawLines(width)
 	for i = start, last do
 		local moveaxis = self.Axises[i]
 		local yellow = false
-		if moveaxis:TestCollision(pl) and not gotselected then
+		if moveaxis:TestCollision(pl, scale, isparentbone or plTable.IsPhysBone) and not gotselected then
 			yellow = true
 			gotselected = true
 		end
-		moveaxis:DrawLines(yellow, scale, width)
+		moveaxis:DrawLines(yellow, scale, width, isparentbone or plTable.IsPhysBone)
 	end
 
 	self.width = width

--- a/lua/entities/rgm_axis/cl_init.lua
+++ b/lua/entities/rgm_axis/cl_init.lua
@@ -8,6 +8,7 @@ local OUTLINE_WIDTH = RGM_Constants.OUTLINE_WIDTH
 local ANGLE_ARROW_OFFSET = Angle(0, 90, 90)
 local ANGLE_DISC = Angle(0, 90, 0)
 
+local GizmoCanGimbalLock = RGMGIZMOS.CanGimbalLock
 local Fulldisc = GetConVar("ragdollmover_fulldisc")
 
 local pl
@@ -19,8 +20,10 @@ function ENT:DrawLines(width)
 	local rotate = plTable.Rotate or false
 	local modescale = plTable.Scale or false
 	local ent = plTable.Entity
-	local bone = plTable.Bone
+	local bone = plTable.Bone or 0
 	local isparentbone = IsValid(ent) and IsValid(ent:GetParent()) and bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll")
+	local isnonphysbone = not (isparentbone or plTable.IsPhysBone)
+	
 	local scale = self.scale
 	local start, last = 1, 7
 	if rotate then start, last = 8, 12 end
@@ -30,12 +33,14 @@ function ENT:DrawLines(width)
 	local gotselected = false
 	for i = start, last do
 		local moveaxis = self.Axises[i]
+		if GizmoCanGimbalLock(moveaxis.gizmotype, isnonphysbone) then continue end
+
 		local yellow = false
-		if moveaxis:TestCollision(pl, scale, isparentbone or plTable.IsPhysBone) and not gotselected then
+		if moveaxis:TestCollision(pl, scale) and not gotselected then
 			yellow = true
 			gotselected = true
 		end
-		moveaxis:DrawLines(yellow, scale, width, isparentbone or plTable.IsPhysBone)
+		moveaxis:DrawLines(yellow, scale, width)
 	end
 
 	self.width = width

--- a/lua/entities/rgm_axis/cl_init.lua
+++ b/lua/entities/rgm_axis/cl_init.lua
@@ -18,8 +18,8 @@ function ENT:DrawLines(scale, width)
 	local rotate = RAGDOLLMOVER[pl].Rotate or false
 	local modescale = RAGDOLLMOVER[pl].Scale or false
 	local start, last = 1, 7
-	if rotate then start, last = 8, 11 end
-	if modescale then start, last = 12, 17 end
+	if rotate then start, last = 8, 12 end
+	if modescale then start, last = 13, 18 end
 	-- print(self.Axises)
 
 	local gotselected = false

--- a/lua/entities/rgm_axis/cl_init.lua
+++ b/lua/entities/rgm_axis/cl_init.lua
@@ -30,17 +30,36 @@ function ENT:DrawLines(width)
 	if modescale then start, last = 13, 18 end
 	-- print(self.Axises)
 
-	local gotselected = false
+	-- First, draw all gizmos for a specific mode as unselected
+	local selected = {}
 	for i = start, last do
 		local moveaxis = self.Axises[i]
 		if GizmoCanGimbalLock(moveaxis.gizmotype, isnonphysbone) then continue end
 
-		local yellow = false
-		if moveaxis:TestCollision(pl, scale) and not gotselected then
-			yellow = true
-			gotselected = true
+		if moveaxis:TestCollision(pl) then
+			table.insert(selected, i)
 		end
-		moveaxis:DrawLines(yellow, scale, width)
+
+		moveaxis:DrawLines(false, scale, width)
+	end
+	
+	-- Then iterate over the selected gizmos and draw a single selected one yellow
+	local gotselected = false
+	local inc = 1
+	start, last = 1, #selected
+	if rotate then start, last, inc = #selected, 1, -1 end -- We also switched the order in `:TestCollision`, so selections are consistent
+	for i = start, last, inc do
+		local moveaxis = self.Axises[selected[i]]
+		if selected[i] and not gotselected then
+			gotselected = moveaxis.id
+		end
+		if moveaxis.IsBall and #selected > 1 then
+			continue
+		end
+
+		if gotselected == moveaxis.id then
+			moveaxis:DrawLines(gotselected == moveaxis.id, scale, width)
+		end
 	end
 
 	self.width = width

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -64,7 +64,7 @@ function ENT:Initialize()
 	end
 end
 
-function ENT:TestCollision(pl)
+function ENT:TestCollision(pl, shouldTest)
 	-- PrintTable(self:GetTable())
 	local rotate = RAGDOLLMOVER[pl].Rotate or false
 	local modescale = RAGDOLLMOVER[pl].Scale or false
@@ -77,7 +77,7 @@ function ENT:TestCollision(pl)
 	for i = start, last do
 		local e = self.Axises[i]
 		-- print(e)
-		local intersect = e:TestCollision(pl)
+		local intersect = e:TestCollision(pl, self.scale, shouldTest)
 		if intersect then return intersect end
 	end
 

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -22,18 +22,18 @@ function ENT:Initialize()
 	self.ArrowXY = RGMGIZMOS.CreateGizmo(2, 5, self, Color(0, 255, 0, 255), Vector(0, 0, -1):Angle(), Color(255, 0, 0, 255))
 	self.ArrowXZ = RGMGIZMOS.CreateGizmo(2, 6, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
 	self.ArrowYZ = RGMGIZMOS.CreateGizmo(2, 7, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
+	
+	self.Ball = RGMGIZMOS.CreateGizmo(5, 8, self, Color(175, 175, 175, 75), Vector(0, 0, 0):Angle())
 
-	self.DiscP = RGMGIZMOS.CreateGizmo(3, 8, self, Color(255, 0, 0, 255), Vector(0, 1, 0):Angle()) -- 0 90 0
+	self.DiscP = RGMGIZMOS.CreateGizmo(3, 9, self, Color(255, 0, 0, 255), Vector(0, 1, 0):Angle()) -- 0 90 0
 	self.DiscP.axistype = 1 -- axistype is a variable to help with setting non physical bones - 1 for pitch, 2 yaw, 3 roll, 4 for the big one
-	self.DiscY = RGMGIZMOS.CreateGizmo(3, 9, self, Color(0, 255, 0, 255), Vector(0, 0, 1):Angle()) -- 270 0 0
+	self.DiscY = RGMGIZMOS.CreateGizmo(3, 10, self, Color(0, 255, 0, 255), Vector(0, 0, 1):Angle()) -- 270 0 0
 	self.DiscY.axistype = 2
-	self.DiscR = RGMGIZMOS.CreateGizmo(3, 10, self, Color(0, 0, 255, 255), Vector(1, 0, 0):Angle()) -- 0 0 0
+	self.DiscR = RGMGIZMOS.CreateGizmo(3, 11, self, Color(0, 0, 255, 255), Vector(1, 0, 0):Angle()) -- 0 0 0
 	self.DiscR.axistype = 3
 
-	self.DiscLarge = RGMGIZMOS.CreateGizmo(4, 11, self, Color(175, 175, 175, 255), Vector(1, 0, 0):Angle())
+	self.DiscLarge = RGMGIZMOS.CreateGizmo(4, 12, self, Color(175, 175, 175, 255), Vector(1, 0, 0):Angle())
 	self.DiscLarge.axistype = 4
-
-	self.Ball = RGMGIZMOS.CreateGizmo(5, 12, self, Color(175, 175, 175, 75), Vector(0, 0, 0):Angle())
 
 	self.ScaleX = RGMGIZMOS.CreateGizmo(6, 13, self, Color(255, 0, 0, 255), Vector(1, 0, 0):Angle())
 	self.ScaleX.axistype = 1
@@ -46,26 +46,11 @@ function ENT:Initialize()
 	self.ScaleXZ = RGMGIZMOS.CreateGizmo(7, 17, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
 	self.ScaleYZ = RGMGIZMOS.CreateGizmo(7, 18, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
 
-	self.Axises = {
-		self.ArrowOmni,
-		self.ArrowX,
-		self.ArrowY,
-		self.ArrowZ,
-		self.ArrowXY,
-		self.ArrowXZ,
-		self.ArrowYZ,
-		self.DiscP,
-		self.DiscY,
-		self.DiscR,
-		self.DiscLarge,
-		self.Ball,
-		self.ScaleX,
-		self.ScaleY,
-		self.ScaleZ,
-		self.ScaleXY,
-		self.ScaleXZ,
-		self.ScaleYZ,
-	}
+	self.Axises = {}
+
+	for i, gizmoName in ipairs(RGMGIZMOS.GizmoTable) do
+		self.Axises[i] = self[gizmoName]
+	end
 
 	self.scale = 0
 	self.width = 0

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -2,6 +2,10 @@
 ENT.Type = "anim"
 ENT.Base = "base_entity"
 
+local GizmoType = RGMGIZMOS.GizmoTypeEnum
+local AxisType = RGMGIZMOS.AxisTypeEnum
+local GizmoCanGimbalLock = RGMGIZMOS.CanGimbalLock
+
 function ENT:Initialize()
 
 	self.DefaultMinMax = Vector(0.1, 0.1, 0.1)
@@ -15,38 +19,41 @@ function ENT:Initialize()
 	self:SetNotSolid(true)
 	self:SetRenderMode(RENDERMODE_TRANSCOLOR)
 
-	self.ArrowOmni = RGMGIZMOS.CreateGizmo(0, 1, self, Color(255, 165, 0, 255), Vector(1, 0, 0):Angle())
+	local CreateGizmo = RGMGIZMOS.GizmoFactory()
 
-	self.ArrowX = RGMGIZMOS.CreateGizmo(1, 2, self, Color(255, 0, 0, 255), Vector(1, 0, 0):Angle())
-	self.ArrowY = RGMGIZMOS.CreateGizmo(1, 3, self, Color(0, 255, 0, 255), Vector(0, 1, 0):Angle())
-	self.ArrowZ = RGMGIZMOS.CreateGizmo(1, 4, self, Color(0, 0, 255, 255), Vector(0, 0, 1):Angle())
+	-- The creation order of the gizmos below must match with `RGMGIZMOS.GizmoTable`
+	self.ArrowOmni = CreateGizmo(GizmoType.OmniPos, self, Color(255, 165, 0, 255), Vector(1, 0, 0):Angle())
 
-	self.ArrowXY = RGMGIZMOS.CreateGizmo(2, 5, self, Color(0, 255, 0, 255), Vector(0, 0, -1):Angle(), Color(255, 0, 0, 255))
-	self.ArrowXZ = RGMGIZMOS.CreateGizmo(2, 6, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
-	self.ArrowYZ = RGMGIZMOS.CreateGizmo(2, 7, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
+	self.ArrowX = CreateGizmo(GizmoType.PosArrow, self, Color(255, 0, 0, 255), Vector(1, 0, 0):Angle())
+	self.ArrowY = CreateGizmo(GizmoType.PosArrow, self, Color(0, 255, 0, 255), Vector(0, 1, 0):Angle())
+	self.ArrowZ = CreateGizmo(GizmoType.PosArrow, self, Color(0, 0, 255, 255), Vector(0, 0, 1):Angle())
+
+	self.ArrowXY = CreateGizmo(GizmoType.PosSide, self, Color(0, 255, 0, 255), Vector(0, 0, -1):Angle(), Color(255, 0, 0, 255))
+	self.ArrowXZ = CreateGizmo(GizmoType.PosSide, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
+	self.ArrowYZ = CreateGizmo(GizmoType.PosSide, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
 	
-	self.Ball = RGMGIZMOS.CreateGizmo(5, 8, self, Color(175, 175, 175, 75), Vector(0, 0, 0):Angle())
+	self.Ball = CreateGizmo(GizmoType.Ball, self, Color(175, 175, 175, 75), Vector(0, 0, 0):Angle())
 
-	self.DiscP = RGMGIZMOS.CreateGizmo(3, 9, self, Color(255, 0, 0, 255), Vector(0, 1, 0):Angle()) -- 0 90 0
-	self.DiscP.axistype = 1 -- axistype is a variable to help with setting non physical bones - 1 for pitch, 2 yaw, 3 roll, 4 for the big one
-	self.DiscY = RGMGIZMOS.CreateGizmo(3, 10, self, Color(0, 255, 0, 255), Vector(0, 0, 1):Angle()) -- 270 0 0
-	self.DiscY.axistype = 2
-	self.DiscR = RGMGIZMOS.CreateGizmo(3, 11, self, Color(0, 0, 255, 255), Vector(1, 0, 0):Angle()) -- 0 0 0
-	self.DiscR.axistype = 3
+	self.DiscP = CreateGizmo(GizmoType.Disc, self, Color(255, 0, 0, 255), Vector(0, 1, 0):Angle()) -- 0 90 0
+	self.DiscP.axistype = AxisType.Pitch -- axistype is a variable to help with setting non physical bones - 1 for pitch, 2 yaw, 3 roll, 4 for the big one
+	self.DiscY = CreateGizmo(GizmoType.Disc, self, Color(0, 255, 0, 255), Vector(0, 0, 1):Angle()) -- 270 0 0
+	self.DiscY.axistype = AxisType.Yaw
+	self.DiscR = CreateGizmo(GizmoType.Disc, self, Color(0, 0, 255, 255), Vector(1, 0, 0):Angle()) -- 0 0 0
+	self.DiscR.axistype = AxisType.Roll
 
-	self.DiscLarge = RGMGIZMOS.CreateGizmo(4, 12, self, Color(175, 175, 175, 255), Vector(1, 0, 0):Angle())
-	self.DiscLarge.axistype = 4
+	self.DiscLarge = CreateGizmo(GizmoType.DiscLarge, self, Color(175, 175, 175, 255), Vector(1, 0, 0):Angle())
+	self.DiscLarge.axistype = AxisType.Large
 
-	self.ScaleX = RGMGIZMOS.CreateGizmo(6, 13, self, Color(255, 0, 0, 255), Vector(1, 0, 0):Angle())
-	self.ScaleX.axistype = 1
-	self.ScaleY = RGMGIZMOS.CreateGizmo(6, 14, self, Color(0, 255, 0, 255), Vector(0, 1, 0):Angle())
-	self.ScaleY.axistype = 2
-	self.ScaleZ = RGMGIZMOS.CreateGizmo(6, 15, self, Color(0, 0, 255, 255), Vector(0, 0, 1):Angle())
-	self.ScaleZ.axistype = 3
+	self.ScaleX = CreateGizmo(GizmoType.ScaleArrow, self, Color(255, 0, 0, 255), Vector(1, 0, 0):Angle())
+	self.ScaleX.axistype = AxisType.X
+	self.ScaleY = CreateGizmo(GizmoType.ScaleArrow, self, Color(0, 255, 0, 255), Vector(0, 1, 0):Angle())
+	self.ScaleY.axistype = AxisType.Y
+	self.ScaleZ = CreateGizmo(GizmoType.ScaleArrow, self, Color(0, 0, 255, 255), Vector(0, 0, 1):Angle())
+	self.ScaleZ.axistype = AxisType.Z
 
-	self.ScaleXY = RGMGIZMOS.CreateGizmo(7, 16, self, Color(0, 255, 0, 255), Vector(0, 0, -1):Angle(), Color(255, 0, 0, 255))
-	self.ScaleXZ = RGMGIZMOS.CreateGizmo(7, 17, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
-	self.ScaleYZ = RGMGIZMOS.CreateGizmo(7, 18, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
+	self.ScaleXY = CreateGizmo(GizmoType.ScaleSide, self, Color(0, 255, 0, 255), Vector(0, 0, -1):Angle(), Color(255, 0, 0, 255))
+	self.ScaleXZ = CreateGizmo(GizmoType.ScaleSide, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
+	self.ScaleYZ = CreateGizmo(GizmoType.ScaleSide, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
 
 	self.Axises = {}
 
@@ -64,10 +71,16 @@ function ENT:Initialize()
 	end
 end
 
-function ENT:TestCollision(pl, shouldTest)
+function ENT:TestCollision(pl)
 	-- PrintTable(self:GetTable())
-	local rotate = RAGDOLLMOVER[pl].Rotate or false
-	local modescale = RAGDOLLMOVER[pl].Scale or false
+	local plTable = RAGDOLLMOVER[pl]
+	local ent = plTable.Entity
+	local bone = plTable.Bone
+	local isparentbone = IsValid(ent) and IsValid(ent:GetParent()) and bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll")
+	local isnonphysbone = not (isparentbone or plTable.IsPhysBone)
+	local rotate = plTable.Rotate or false
+	local modescale = plTable.Scale or false
+	
 	local start, last = 1, 7
 
 	if rotate then start, last = 8, 12 end
@@ -76,8 +89,9 @@ function ENT:TestCollision(pl, shouldTest)
 	if not self.Axises then return false end
 	for i = start, last do
 		local e = self.Axises[i]
+		if GizmoCanGimbalLock(e.gizmotype, isnonphysbone) then continue end
 		-- print(e)
-		local intersect = e:TestCollision(pl, self.scale, shouldTest)
+		local intersect = e:TestCollision(pl, self.scale)
 		if intersect then return intersect end
 	end
 

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -81,17 +81,17 @@ function ENT:TestCollision(pl)
 	local rotate = plTable.Rotate or false
 	local modescale = plTable.Scale or false
 	
-	local start, last = 1, 7
+	local start, last, inc = 1, 7, 1
 
-	if rotate then start, last = 8, 12 end
+	if rotate then start, last, inc = 12, 8, -1 end
 	if modescale then start, last = 13, 18 end
 
 	if not self.Axises then return false end
-	for i = start, last do
+	for i = start, last, inc do
 		local e = self.Axises[i]
 		if GizmoCanGimbalLock(e.gizmotype, isnonphysbone) then continue end
 		-- print(e)
-		local intersect = e:TestCollision(pl, self.scale)
+		local intersect = e:TestCollision(pl)
 		if intersect then return intersect end
 	end
 

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -32,7 +32,7 @@ function ENT:Initialize()
 	self.ArrowXZ = CreateGizmo(GizmoType.PosSide, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
 	self.ArrowYZ = CreateGizmo(GizmoType.PosSide, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
 	
-	self.Ball = CreateGizmo(GizmoType.Ball, self, Color(175, 175, 175, 75), Vector(0, 0, 0):Angle())
+	self.Ball = CreateGizmo(GizmoType.Ball, self, Color(255, 255, 255, 5), Vector(0, 0, 0):Angle())
 
 	self.DiscP = CreateGizmo(GizmoType.Disc, self, Color(255, 0, 0, 255), Vector(0, 1, 0):Angle()) -- 0 90 0
 	self.DiscP.axistype = AxisType.Pitch -- axistype is a variable to help with setting non physical bones - 1 for pitch, 2 yaw, 3 roll, 4 for the big one

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -11,6 +11,7 @@ function ENT:Initialize()
 	self:SetCollisionBounds(Vector(-0.1, -0.1, -0.1), Vector(0.1, 0.1, 0.1))
 	self:SetSolid(SOLID_VPHYSICS)
 	self:SetNotSolid(true)
+	self:SetRenderMode(RENDERMODE_TRANSCOLOR)
 
 	self.ArrowOmni = RGMGIZMOS.CreateGizmo(0, 1, self, Color(255, 165, 0, 255), Vector(1, 0, 0):Angle())
 
@@ -32,16 +33,18 @@ function ENT:Initialize()
 	self.DiscLarge = RGMGIZMOS.CreateGizmo(4, 11, self, Color(175, 175, 175, 255), Vector(1, 0, 0):Angle())
 	self.DiscLarge.axistype = 4
 
-	self.ScaleX = RGMGIZMOS.CreateGizmo(5, 12, self, Color(255, 0, 0, 255), Vector(1, 0, 0):Angle())
+	self.Ball = RGMGIZMOS.CreateGizmo(5, 12, self, Color(175, 175, 175, 75), Vector(0, 0, 0):Angle())
+
+	self.ScaleX = RGMGIZMOS.CreateGizmo(6, 13, self, Color(255, 0, 0, 255), Vector(1, 0, 0):Angle())
 	self.ScaleX.axistype = 1
-	self.ScaleY = RGMGIZMOS.CreateGizmo(5, 13, self, Color(0, 255, 0, 255), Vector(0, 1, 0):Angle())
+	self.ScaleY = RGMGIZMOS.CreateGizmo(6, 14, self, Color(0, 255, 0, 255), Vector(0, 1, 0):Angle())
 	self.ScaleY.axistype = 2
-	self.ScaleZ = RGMGIZMOS.CreateGizmo(5, 14, self, Color(0, 0, 255, 255), Vector(0, 0, 1):Angle())
+	self.ScaleZ = RGMGIZMOS.CreateGizmo(6, 15, self, Color(0, 0, 255, 255), Vector(0, 0, 1):Angle())
 	self.ScaleZ.axistype = 3
 
-	self.ScaleXY = RGMGIZMOS.CreateGizmo(6, 15, self, Color(0, 255, 0, 255), Vector(0, 0, -1):Angle(), Color(255, 0, 0, 255))
-	self.ScaleXZ = RGMGIZMOS.CreateGizmo(6, 16, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
-	self.ScaleYZ = RGMGIZMOS.CreateGizmo(6, 17, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
+	self.ScaleXY = RGMGIZMOS.CreateGizmo(7, 16, self, Color(0, 255, 0, 255), Vector(0, 0, -1):Angle(), Color(255, 0, 0, 255))
+	self.ScaleXZ = RGMGIZMOS.CreateGizmo(7, 17, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
+	self.ScaleYZ = RGMGIZMOS.CreateGizmo(7, 18, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
 
 	self.Axises = {
 		self.ArrowOmni,
@@ -55,12 +58,13 @@ function ENT:Initialize()
 		self.DiscY,
 		self.DiscR,
 		self.DiscLarge,
+		self.Ball,
 		self.ScaleX,
 		self.ScaleY,
 		self.ScaleZ,
 		self.ScaleXY,
 		self.ScaleXZ,
-		self.ScaleYZ
+		self.ScaleYZ,
 	}
 
 	self.scale = 0
@@ -73,8 +77,8 @@ function ENT:TestCollision(pl, scale)
 	local modescale = RAGDOLLMOVER[pl].Scale or false
 	local start, last = 1, 7
 
-	if rotate then start, last = 8, 11 end
-	if modescale then start, last = 12, 17 end
+	if rotate then start, last = 8, 12 end
+	if modescale then start, last = 13, 18 end
 
 	if not self.Axises then return false end
 	for i = start, last do

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -13,7 +13,7 @@ RGMGIZMOS.AxisTypeEnum = {
 local VECTOR_FRONT = RGM_Constants.VECTOR_FRONT
 local VECTOR_SIDE = RGM_Constants.VECTOR_LEFT
 local COLOR_BRIGHT_YELLOW = RGM_Constants.COLOR_BRIGHT_YELLOW
-local COLOR_BRIGHT_YELLOW2 = ColorAlpha(COLOR_BRIGHT_YELLOW, 100)
+local COLOR_BRIGHT_YELLOW2 = ColorAlpha(COLOR_BRIGHT_YELLOW, 6)
 
 local PARENTED_BONE = 0
 local PHYSICAL_BONE = 1
@@ -1390,6 +1390,7 @@ RGMGIZMOS.GizmoTypeEnum = {
 -- Nonphysical bones don't fare well with free rotations because of gimbal lock, so we disable certain gizmos that may cause them
 local GimbalLockProne = {
 	[RGMGIZMOS.GizmoTypeEnum.DiscLarge] = true,
+	[RGMGIZMOS.GizmoTypeEnum.Ball] = true,
 }
 
 ---------------

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -1002,7 +1002,7 @@ local disclarge = table.Copy(disc)
 
 do
 
-	function disclarge:TestCollision(pl, scale)
+	function disclarge:TestCollision(pl)
 		local plTable = RAGDOLLMOVER[pl]
 		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
 		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
@@ -1061,21 +1061,24 @@ do
 		return intersect
 	end
 
-	function ball:TestCollision(pl, scale)
+	function ball:TestCollision(pl)
 		if GetConVar("ragdollmover_drawsphere"):GetInt() <= 0 then return end 
 
 		local plTable = RAGDOLLMOVER[pl]
 		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
 		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
 		local intersect = self:GetGrabPos(eyepos, eyeang)
-		local distmin = 0
-		local distmax = scale
+		local distmin, distmax = self.collpositions[1], self.collpositions[2]
 		local dist = intersect:Distance(self:GetPos())
 		if dist >= distmin and dist <= distmax then
 			debugoverlay.Sphere(intersect, 1, 0.1, Color(0,0,255), true)
 			return {axis = self, hitpos = intersect}
 		end
 		return false
+	end
+
+	function ball:CalculateGizmo(scale)
+		self.collpositions = { 0, scale }
 	end
 
 	if SERVER then

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -789,9 +789,6 @@ do
 				local pos = self:GetPos()
 				local ang = self:LocalToWorldAngles(Angle(0, 0, rotationangle))
 
-				debugoverlay.Text(axis.BonePos + vector_up * 0, ang.x, 0, false)
-				debugoverlay.Text(axis.BonePos + vector_up * 10, ang.y, 0, false)
-				debugoverlay.Text(axis.BonePos + vector_up * 20, ang.z, 0, false)
 				if axis.relativerotate then
 					offset = WorldToLocal(axis.BonePos, angle_zero, axis:GetPos(), axis.LocalAngles)
 					_p, _a = LocalToWorld(vector_origin, offang, pos, ang)
@@ -1071,7 +1068,6 @@ do
 		local distmin, distmax = self.collpositions[1], self.collpositions[2]
 		local dist = intersect:Distance(self:GetPos())
 		if dist >= distmin and dist <= distmax then
-			debugoverlay.Sphere(intersect, 1, 0.1, Color(0,0,255), true)
 			return {axis = self, hitpos = intersect}
 		end
 		return false

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -1011,6 +1011,8 @@ local ball = table.Copy(basepart)
 
 do
 	function ball:TestCollision(pl, scale)
+		if GetConVar("ragdollmover_drawsphere"):GetInt() <= 0 then return end 
+
 		local plTable = RAGDOLLMOVER[pl]
 		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
 		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
@@ -1026,7 +1028,7 @@ do
 
 	if SERVER then
 		function ball:ProcessMovement(_, offang, eyepos, eyeang, ent, bone, ppos, pnorm, movetype, snapamount, startangle, _, nphysangle)
-			local intersect = self:GetGrabPos(eyepos, eyeang, ppos, pnorm)
+			local intersect = self:GetGrabPos(eyepos, eyeang, ppos, -eyeang:Forward())
 			local localized = self:WorldToLocal(intersect)
 			local _p, _a
 			local axis = self.Parent
@@ -1045,6 +1047,7 @@ do
 
 	if CLIENT then
 		function ball:DrawLines(yellow, scale)
+			if GetConVar("ragdollmover_drawsphere"):GetInt() <= 0 then return end 
 			local color = self:GetColor()
 			color = Color(color[1], color[2], color[3], color[4])
 			if yellow then

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -1100,7 +1100,9 @@ do
 				local startpoint = startangle
 				local delta = localized - startpoint
 
-				local rotationAngle = delta:Length()
+				-- Estimated length required to reach the 90 degree mark, if rotating from the center of the sphere 
+				local factor = 90 / self.collpositions[2]
+				local rotationAngle = delta:Length() * factor
 				rotationAngle = isnan(rotationAngle) and rotationAngle or 0
 				if snapamount ~= 0 then
 					rotationAngle = math.floor(rotationAngle / snapamount) * snapamount

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -990,7 +990,9 @@ local disclarge = table.Copy(disc)
 
 do
 
-	function disclarge:TestCollision(pl)
+	function disclarge:TestCollision(pl, scale, shouldTest)
+		if not shouldTest then return false end
+
 		local plTable = RAGDOLLMOVER[pl]
 		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
 		local eyepos, eyeang = rgm.EyePosAng(pl, plviewent)
@@ -1010,7 +1012,9 @@ do
 
 	if CLIENT then
 
-		function disclarge:DrawLines(yellow, scale, width)
+		function disclarge:DrawLines(yellow, scale, width, shouldDraw)
+			if not shouldDraw then return end
+
 			local toscreen = {}
 			local linetable = self:GetLinePositions(width)
 			local color = self:GetColor()
@@ -1049,8 +1053,9 @@ do
 		return intersect
 	end
 
-	function ball:TestCollision(pl, scale)
+	function ball:TestCollision(pl, scale, shouldTest)
 		if GetConVar("ragdollmover_drawsphere"):GetInt() <= 0 then return end 
+		if not shouldTest then return false end
 
 		local plTable = RAGDOLLMOVER[pl]
 		local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or nil)
@@ -1137,8 +1142,10 @@ do
 	end
 
 	if CLIENT then
-		function ball:DrawLines(yellow, scale)
+		function ball:DrawLines(yellow, scale, width, shouldDraw)
 			if GetConVar("ragdollmover_drawsphere"):GetInt() <= 0 then return end 
+			if not shouldDraw then return end
+
 			local color = self:GetColor()
 			color = Color(color[1], color[2], color[3], color[4])
 			if yellow then

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -1116,29 +1116,26 @@ do
 					rotationAngle = math.floor(rotationAngle / snapamount) * snapamount
 				end
 				local rotationAxis = planeNormal:Cross(delta):GetNormalized()
-				rotationAxis = rotationAxis:IsZero() and vector_up or rotationAxis
-
-				-- debugoverlay.Sphere(intersect, 1, 0.1, Color(255, 0, 255), true)
-				-- debugoverlay.Sphere(self:LocalToWorld(startangle), 1, 0.1, Color(0, 255, 0), true)
-				-- debugoverlay.Line(self:LocalToWorld(startangle), self:LocalToWorld(startangle + delta), 0.1, Color(255, 0, 0), true)
-				-- debugoverlay.Line(self:LocalToWorld(startangle), self:LocalToWorld(startangle + rotationAxis * 40), 0.1, Color(255, 127, 0), true)
+				rotationAxis = rotationAxis:IsZero() and vector_origin or rotationAxis
 
 				if self.LastStartAngle ~= startangle then
-					local _, lastAngle = ent:GetBonePosition(bone)
+					local physObj = ent:GetPhysicsObjectNum(bone)
+
+					local lastAngle
+					if IsValid(physObj) then
+						lastAngle = physObj:GetAngles()
+					end
 					self.LastAngle = lastAngle * 1
 					self.LastStartAngle = startangle
 				end
 
 				local pos = self:GetPos()
-				local ang = self.LastAngle * 1
+				local ang = angle_zero * 1
 				ang:RotateAroundAxis(rotationAxis, rotationAngle)
 				
 				ang = self:LocalToWorldAngles(ang)
 
-				debugoverlay.Text(axis.BonePos + vector_up * 0, ang.x, 0, false)
-				debugoverlay.Text(axis.BonePos + vector_up * 10, ang.y, 0, false)
-				debugoverlay.Text(axis.BonePos + vector_up * 20, ang.z, 0, false)
-				_p, _a = LocalToWorld(vector_origin, offang, pos, ang)
+				_p, _a = LocalToWorld(vector_origin, self:WorldToLocalAngles(self.LastAngle), pos, ang)
 				if axis.relativerotate then
 					offset = WorldToLocal(axis.BonePos, angle_zero, axis:GetPos(), axis.LocalAngles)
 					_p = LocalToWorld(offset, _a, pos, _a)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1937,7 +1937,8 @@ function TOOL:LeftClick()
 	end
 
 	local ent = plTable.Entity
-	local collision = axis:TestCollision(pl)
+	local isparentbone = IsValid(ent) and IsValid(ent:GetParent()) and plTable.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll")
+	local collision = axis:TestCollision(pl, isparentbone or plTable.IsPhysBone)
 
 	if collision and IsValid(ent) and rgmCanTool(ent, pl) then
 

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -20,6 +20,7 @@ TOOL.ClientConVar["scalerelativemove"] = 0
 TOOL.ClientConVar["drawskeleton"] = 0
 TOOL.ClientConVar["snapenable"] = 0
 TOOL.ClientConVar["snapamount"] = 30
+TOOL.ClientConVar["drawsphere"] = 1
 
 TOOL.ClientConVar["ik_leg_L"] = 0
 TOOL.ClientConVar["ik_leg_R"] = 0

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -4430,7 +4430,7 @@ end)
 local material = CreateMaterial("rgmGizmoMaterial", "UnlitGeneric", {
 	["$basetexture"] = 	"color/white",
   	["$model"] = 		1,
- 	["$alphatest"] = 	1,
+ 	["$translucent"] = 	1,
  	["$vertexalpha"] = 	1,
  	["$vertexcolor"] = 	1,
  	["$ignorez"] = 		1,

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -2581,7 +2581,7 @@ do
 			net.SendToServer()
 			if k == 8 then
 				if not pl or not RAGDOLLMOVER[pl] or not IsValid(RAGDOLLMOVER[pl].Axis) then return end
-				RAGDOLLMOVER[pl].Axis.scale = new
+				RAGDOLLMOVER[pl].Axis.scale = tonumber(new)
 				RAGDOLLMOVER[pl].Axis:CalculateGizmo()
 			elseif k == 14 then
 				RAGDOLLMOVER[pl].always_use_pl_view = tonumber(new)

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1765,33 +1765,45 @@ concommand.Add("ragdollmover_resetroot", function(pl)
 	net.Send(pl)
 end)
 
+local function spawnAxis(pl, tool, plTable)
+	local axis = ents.Create("rgm_axis")
+	axis:SetPos(pl:EyePos())
+	axis:Spawn()
+	axis.Owner = pl
+	axis.localpos = tool:GetClientNumber("localpos", 0) ~= 0
+	axis.localang = tool:GetClientNumber("localang", 1) ~= 0
+	axis.localoffset = tool:GetClientNumber("localoffset", 1) ~= 0
+	axis.relativerotate = tool:GetClientNumber("relativerotate", 0) ~= 0
+	axis.scalechildren = tool:GetClientNumber("scalechildren", 0) ~= 0
+	axis.smovechildren = tool:GetClientNumber("smovechildren", 0) ~= 0
+	axis.scalerelativemove = tool:GetClientNumber("scalerelativemove", 0) ~= 0
+	plTable.Axis = axis
+
+	plTable.updaterate = tool:GetClientNumber("updaterate", 0.01)
+	plTable.unfreeze = tool:GetClientNumber("unfreeze", 0)
+	plTable.snapenable = tool:GetClientNumber("snapenable", 0)
+	plTable.snapamount = tool:GetClientNumber("snapamount", 30)
+	plTable.physmove = tool:GetClientNumber("physmove", 0)
+	plTable.always_use_pl_view = tool:GetClientNumber("always_use_pl_view", 0)
+
+	RAGDOLLMOVER.Sync(pl, "Axis", "always_use_pl_view")
+end
+
+concommand.Add("ragdollmover_resetgizmo", function(pl)
+	local plTable = RAGDOLLMOVER[pl]
+	if not plTable or not IsValid(plTable.Axis) then return end
+
+	plTable.Axis:Remove()
+	spawnAxis(pl, pl:GetTool(), plTable)
+end)
+
 function TOOL:Deploy()
 	if SERVER then
 		local pl = self:GetOwner()
 		local plTable = RAGDOLLMOVER[pl]
 		local axis = plTable.Axis
 		if not IsValid(axis) then
-			axis = ents.Create("rgm_axis")
-			axis:SetPos(pl:EyePos())
-			axis:Spawn()
-			axis.Owner = pl
-			axis.localpos = self:GetClientNumber("localpos", 0) ~= 0
-			axis.localang = self:GetClientNumber("localang", 1) ~= 0
-			axis.localoffset = self:GetClientNumber("localoffset", 1) ~= 0
-			axis.relativerotate = self:GetClientNumber("relativerotate", 0) ~= 0
-			axis.scalechildren = self:GetClientNumber("scalechildren", 0) ~= 0
-			axis.smovechildren = self:GetClientNumber("smovechildren", 0) ~= 0
-			axis.scalerelativemove = self:GetClientNumber("scalerelativemove", 0) ~= 0
-			plTable.Axis = axis
-
-			plTable.updaterate = self:GetClientNumber("updaterate", 0.01)
-			plTable.unfreeze = self:GetClientNumber("unfreeze", 0)
-			plTable.snapenable = self:GetClientNumber("snapenable", 0)
-			plTable.snapamount = self:GetClientNumber("snapamount", 30)
-			plTable.physmove = self:GetClientNumber("physmove", 0)
-			plTable.always_use_pl_view = self:GetClientNumber("always_use_pl_view", 0)
-
-			RAGDOLLMOVER.Sync(pl, "Axis", "always_use_pl_view")
+			spawnAxis(pl, self, plTable)
 		end
 	end
 end
@@ -1866,29 +1878,7 @@ function TOOL:LeftClick()
 
 	local axis = plTable.Axis
 	if not IsValid(axis) then
-		axis = ents.Create("rgm_axis")
-		axis:SetPos(pl:EyePos())
-		axis:Spawn()
-		axis.Owner = pl
-		axis.localpos = self:GetClientNumber("localpos", 0) ~= 0
-		axis.localang = self:GetClientNumber("localang", 1) ~= 0
-		axis.localoffset = self:GetClientNumber("localoffset", 1) ~= 0
-		axis.relativerotate = self:GetClientNumber("relativerotate", 0) ~= 0
-		axis.scalechildren = self:GetClientNumber("scalechildren", 0) ~= 0
-		axis.smovechildren = self:GetClientNumber("smovechildren", 0) ~= 0
-		axis.scalerelativemove = self:GetClientNumber("scalerelativemove", 0) ~= 0
-		plTable.Axis = axis
-
-		plTable.updaterate = self:GetClientNumber("updaterate", 0.01)
-		plTable.unfreeze = self:GetClientNumber("unfreeze", 0)
-		plTable.snapenable = self:GetClientNumber("snapenable", 0)
-		plTable.snapamount = self:GetClientNumber("snapamount", 30)
-		plTable.physmove = self:GetClientNumber("physmove", 0)
-		plTable.always_use_pl_view = self:GetClientNumber("always_use_pl_view", 0)
-
-		plTable.Axis = axis
-
-		RAGDOLLMOVER.Sync(pl, "Axis", "always_use_pl_view")
+		spawnAxis(pl, self, plTable)
 		return false
 	end
 

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1937,8 +1937,7 @@ function TOOL:LeftClick()
 	end
 
 	local ent = plTable.Entity
-	local isparentbone = IsValid(ent) and IsValid(ent:GetParent()) and plTable.Bone == 0 and not ent:IsEffectActive(EF_BONEMERGE) and not ent:IsEffectActive(EF_FOLLOWBONE) and not (ent:GetClass() == "prop_ragdoll")
-	local collision = axis:TestCollision(pl, isparentbone or plTable.IsPhysBone)
+	local collision = axis:TestCollision(pl)
 
 	if collision and IsValid(ent) and rgmCanTool(ent, pl) then
 


### PR DESCRIPTION
- Adds a ball gizmo to the rotation mode, which allows physical bones or parented bones (such as the root bone of an effect prop's entity) to be rotated in any arbitrary direction. Resolves #21
- Hides the ball and large, gray disc gizmo when accessing nonphysical bones, as these bones are more likely to gimbal lock from rotation at any axis. (Rotating a nonphysical bone from any arbitrary axis is an open problem that any can attempt to solve).