### PR TITLE
UI Adjustments

### DIFF
--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -20,7 +20,7 @@ TOOL.ClientConVar["scalerelativemove"] = 0
 TOOL.ClientConVar["drawskeleton"] = 0
 TOOL.ClientConVar["snapenable"] = 0
 TOOL.ClientConVar["snapamount"] = 30
-TOOL.ClientConVar["drawsphere"] = 1
+TOOL.ClientConVar["drawsphere"] = 0
 
 TOOL.ClientConVar["ik_leg_L"] = 0
 TOOL.ClientConVar["ik_leg_R"] = 0

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -4193,11 +4193,11 @@ local function RGMBuildConstrainedEnts(parent, children, entpanel)
 	end
 end
 
-local function RGMMakeBoneButtonPanel(cat, cpanel)
+local function RGMMakeBoneButtonPanel(col)
 	local plTable = RAGDOLLMOVER[pl]
-	local parentpanel = vgui.Create("Panel", cat)
+	local parentpanel = vgui.Create("Panel", col)
 	parentpanel:SetSize(100, 30)
-	cat:AddItem(parentpanel)
+	col:AddItem(parentpanel)
 
 	parentpanel.ShowAll = vgui.Create("DButton", parentpanel)
 	parentpanel.ShowAll:Dock(FILL)
@@ -4230,6 +4230,33 @@ local function RGMMakeBoneButtonPanel(cat, cpanel)
 	end
 
 	return parentpanel
+end
+
+local function RGMMakeAngleSnap(col)
+	local parentpanel = vgui.Create("DPanelList", col)
+	parentpanel:EnableHorizontal(false)
+
+	local snapcheck = CCheckBox(parentpanel, "#tool.ragdollmover.snapenable", "ragdollmover_snapenable")
+	local snapslider = CNumSlider(parentpanel, "#tool.ragdollmover.snapamount", "ragdollmover_snapamount", 1, 180, 0)
+
+	function snapcheck:OnChange(val)
+		val = tobool(val)
+		if self.expanded == val then return end
+
+		self.expanded = val
+		snapslider:SetVisible(val)
+
+		parentpanel:InvalidateLayout()
+		parentpanel:GetParent():InvalidateLayout()
+	end
+
+	parentpanel.OldPerform = parentpanel.PerformLayout
+	function parentpanel:PerformLayout()
+		self:OldPerform()
+		self:SizeToChildren(false, true)
+	end
+
+	col:AddItem(parentpanel)
 end
 
 local function rgmDoNotification(message)
@@ -4277,11 +4304,7 @@ function TOOL.BuildCPanel(CPanel)
 		CB:SetToolTip("#tool.ragdollmover.unfreezetip")
 		local DisFil = CCheckBox(Col3, "#tool.ragdollmover.disablefilter", "ragdollmover_disablefilter")
 		DisFil:SetToolTip("#tool.ragdollmover.disablefiltertip")
-		local physmovecheck = CCheckBox(Col3, "#tool.ragdollmover.physmove", "ragdollmover_physmove")
-		physmovecheck:SetToolTip("#tool.ragdollmover.physmovetip")
 		CCheckBox(Col3, "#tool.ragdollmover.drawskeleton", "ragdollmover_drawskeleton")
-		CCheckBox(Col3, "#tool.ragdollmover.snapenable", "ragdollmover_snapenable")
-		CNumSlider(Col3, "#tool.ragdollmover.snapamount", "ragdollmover_snapamount", 1, 180, 0)
 		CNumSlider(Col3, "#tool.ragdollmover.updaterate", "ragdollmover_updaterate", 0.01, 1.0, 2)
 
 	CBinder(CPanel)
@@ -4318,13 +4341,18 @@ function TOOL.BuildCPanel(CPanel)
 
 			CButton(ColManip, "#tool.ragdollmover.resetallbones", RGMResetAllBones)
 
+		local physmovecheck = CCheckBox(Col4, "#tool.ragdollmover.physmove", "ragdollmover_physmove")
+		physmovecheck:SetToolTip("#tool.ragdollmover.physmovetip")
+		RGMMakeAngleSnap(Col4)
+		
+
 		local Col5 = CCol(Col4, "#tool.ragdollmover.scaleoptions", true) 
 		CCheckBox(Col5, "#tool.ragdollmover.scalechildren", "ragdollmover_scalechildren")
 		CCheckBox(Col5, "#tool.ragdollmover.smovechildren", "ragdollmover_smovechildren")
 		CCheckBox(Col5, "#tool.ragdollmover.scalerelativemove", "ragdollmover_scalerelativemove")
 
 		local ColBones = CCol(Col4, "#tool.ragdollmover.bonelist")
-			RGMMakeBoneButtonPanel(ColBones, CPanel)
+			RGMMakeBoneButtonPanel(ColBones)
 			BonePanel = vgui.Create("DTree", ColBones)
 			BonePanel:SetTall(600)
 			AddHBar(BonePanel)


### PR DESCRIPTION
Angle snapping and "Move physbones with nonphysbones" settings were moved under bone manipulation tab rather than misc one, and activating angle snapping will now show slider for setting angle snap angles, which is now hidden by default.

Convar for enabling spherical rotation gizmo is now disabled by default when first installing the update (ragdollmover_drawsphere). Shouldn't affect those who already had the version with spherical gizmo and had it enabled