### PR TITLE
Scale Text

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -79,9 +79,16 @@ function EyePosAng(pl, viewent)
 			eyepos = viewent:LocalToWorld(viewent:GetViewOffset())
 		end
 	end
-	local cursorvec = pl:GetAimVector()
+	local cursorvec = pl:GetAimVector():Angle()
+	local _, lookAng = WorldToLocal(vector_origin, cursorvec, vector_origin, pl:EyeAngles())
+	-- If the cursor is visible
+	if not lookAng:IsEqualTol(angle_zero, 2) then
+		local cv, ca = WorldToLocal(vector_origin, cursorvec, vector_origin, pl:GetViewEntity():EyeAngles())
+		-- Rotate the cursor vector to the current view entity's eye angles
+		_, cursorvec = LocalToWorld(cv, ca, vector_origin, viewent:EyeAngles())
+	end
 	--local cursorvec = pl:EyeAngles()
-	return eyepos, cursorvec:Angle()
+	return eyepos, cursorvec
 end
 
 function AbsVector(vec)

--- a/lua/entities/rgm_axis/cl_init.lua
+++ b/lua/entities/rgm_axis/cl_init.lua
@@ -106,14 +106,15 @@ local lastang = nil
 function ENT:Think()
 	if not pl or not RAGDOLLMOVER[pl] then return end
 	if self ~= RAGDOLLMOVER[pl].Axis then return end
+	local plTable = RAGDOLLMOVER[pl]
 
-	local ent = RAGDOLLMOVER[pl].Entity
-	if not IsValid(ent) or not RAGDOLLMOVER[pl].Bone or not self.Axises then return end
+	local ent = plTable.Entity
+	if not IsValid(ent) or not plTable.Bone or not self.Axises then return end
 
-	if not RAGDOLLMOVER[pl].Moving then -- Prevent whole thing from rotating when we do localized rotation
-		if RAGDOLLMOVER[pl].Rotate then
-			if not RAGDOLLMOVER[pl].IsPhysBone then
-				local manipang = ent:GetManipulateBoneAngles(RAGDOLLMOVER[pl].Bone)
+	if not plTable.Moving then -- Prevent whole thing from rotating when we do localized rotation
+		if plTable.Rotate then
+			if not plTable.IsPhysBone then
+				local manipang = ent:GetManipulateBoneAngles(plTable.Bone)
 				if manipang ~= lastang then
 					self.DiscP.LocalAng = Angle(0, 90 + manipang.y, 0) -- Pitch follows Yaw angles
 					self.DiscR.LocalAng = Angle(0 + manipang.x, 0 + manipang.y, 0) -- Roll follows Pitch and Yaw angles
@@ -131,12 +132,8 @@ function ENT:Think()
 		end
 	end
 
-	local pos, poseye = self:GetPos(), pl:EyePos()
-
-	local viewent = pl:GetViewEntity()
-	if IsValid(viewent) and viewent ~= pl then
-		poseye = viewent:GetPos()
-	end
+	local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or pl:GetViewEntity())
+	local pos, poseye = self:GetPos(), plviewent:EyePos()
 
 	local ang = (pos - poseye):Angle()
 	ang = self:WorldToLocalAngles(ang)

--- a/lua/entities/rgm_axis/init.lua
+++ b/lua/entities/rgm_axis/init.lua
@@ -297,12 +297,8 @@ function ENT:Think()
 		self.NMBonePos = LocalToWorld(-ent:GetManipulateBonePosition(bone), angle_zero, pos, self.GizmoParent)
 	end
 
-	local viewent = pl:GetViewEntity()
-	local pos, poseye = self:GetPos(), pl:EyePos()
-
-	if IsValid(viewent) and viewent ~= pl then
-		poseye = viewent:GetPos()
-	end
+	local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or pl:GetViewEntity())
+	local pos, poseye = self:GetPos(), plviewent:EyePos()
 
 	local disc = self.DiscLarge
 	local ang = (pos - poseye):Angle()

--- a/lua/entities/rgm_axis/shared.lua
+++ b/lua/entities/rgm_axis/shared.lua
@@ -52,8 +52,11 @@ function ENT:Initialize()
 	self.ScaleZ.axistype = AxisType.Z
 
 	self.ScaleXY = CreateGizmo(GizmoType.ScaleSide, self, Color(0, 255, 0, 255), Vector(0, 0, -1):Angle(), Color(255, 0, 0, 255))
+	self.ScaleXY.axistype = AxisType.XY
 	self.ScaleXZ = CreateGizmo(GizmoType.ScaleSide, self, Color(255, 0, 0, 255), Vector(0, -1, 0):Angle(), Color(0, 0, 255, 255))
+	self.ScaleXZ.axistype = AxisType.XZ
 	self.ScaleYZ = CreateGizmo(GizmoType.ScaleSide, self, Color(0, 255, 0, 255), Vector(1, 0, 0):Angle(), Color(0, 0, 255, 255))
+	self.ScaleYZ.axistype = AxisType.YZ
 
 	self.Axises = {}
 

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -784,12 +784,13 @@ do
 			local axis = self.Parent
 			local pl = axis.Owner
 			local plTable = RAGDOLLMOVER[pl]
+			local plviewent = plTable.always_use_pl_view == 1 and pl or (plTable.PlViewEnt ~= 0 and Entity(plTable.PlViewEnt) or pl:GetViewEntity())
 
 			local axistable = {
 				(axis:LocalToWorld(VECTOR_SIDE) - self:GetPos()):Angle(),
 				(axis:LocalToWorld(vector_up) - self:GetPos()):Angle(),
 				(axis:LocalToWorld(VECTOR_FRONT) - self:GetPos()):Angle(),
-				(self:GetPos() - pl:EyePos()):Angle()
+				(self:GetPos() - plviewent:GetPos()):Angle()
 			}
 			axistable[1]:Normalize()
 			axistable[2]:Normalize()

--- a/lua/ragdollmover/rgm_gizmos.lua
+++ b/lua/ragdollmover/rgm_gizmos.lua
@@ -8,18 +8,25 @@ RGMGIZMOS.AxisTypeEnum = {
 	X = 1,
 	Y = 2,
 	Z = 3,
+	XY = 1,
+	XZ = 2,
+	YZ = 3
 }
 
 local VECTOR_FRONT = RGM_Constants.VECTOR_FRONT
 local VECTOR_SIDE = RGM_Constants.VECTOR_LEFT
 local COLOR_BRIGHT_YELLOW = RGM_Constants.COLOR_BRIGHT_YELLOW
 local COLOR_BRIGHT_YELLOW2 = ColorAlpha(COLOR_BRIGHT_YELLOW, 6)
+local COLOR_RGMBLACK = RGM_Constants.COLOR_BLACK
+local OUTLINE_WIDTH = RGM_Constants.OUTLINE_WIDTH
 
 local PARENTED_BONE = 0
 local PHYSICAL_BONE = 1
 local NONPHYSICAL_BONE = 2
 
 local AxisType = RGMGIZMOS.AxisTypeEnum
+
+local Round = math.Round
 
 local function isnan(num)
 	return num == num
@@ -103,9 +110,9 @@ do
 
 	function basepart:SetColor(color, num)
 		if num == 2 then
-			self.Color2 = color:ToTable()
+			self.Color2 = color
 		else
-			self.Color = color:ToTable()
+			self.Color = color
 		end
 	end
 
@@ -113,9 +120,9 @@ do
 		local color
 
 		if num == 2 then
-			color = table.Copy(self.Color2)
+			color = self.Color2
 		else
-			color = table.Copy(self.Color)
+			color = self.Color
 		end
 
 		return color
@@ -165,7 +172,6 @@ do
 			local toscreen = {}
 			local linetable = self:GetLinePositions(width)
 			local color = self:GetColor()
-			color = Color(color[1], color[2], color[3], color[4])
 
 			for i, v in ipairs(linetable) do
 				local points = self:PointsToWorld(v, scale)
@@ -506,12 +512,8 @@ do
 			local toscreen = {}
 			local linetable = self:GetLinePositions(width)
 			local color = self:GetColor()
-			color = Color(color[1], color[2], color[3], color[4])
 
 			local color2 = self:GetColor(2)
-			if color2 then
-				color2 = Color(color2[1], color2[2], color2[3], color2[4])
-			end
 
 			for i, v in ipairs(linetable) do
 				local points = self:PointsToWorld(v, scale)
@@ -971,7 +973,6 @@ do
 
 			local borderpos = largedisc:GetPos()
 			local color = self:GetColor()
-			color = Color(color[1], color[2], color[3], color[4])
 
 			local moving = RAGDOLLMOVER[pl].Moving or false
 
@@ -990,6 +991,17 @@ do
 			for i,v in ipairs(toscreen) do
 				render.DrawQuad(v[1][1], v[1][2], v[1][3], v[1][4], v[2])
 			end
+		end
+
+		function disc:DrawText(plTable, eyepos, eyeang)
+			local parent = self.Parent
+			local intersect = self:GetGrabPos(eyepos, eyeang)
+			local fwd = (intersect - parent:GetPos())
+			fwd:Normalize()
+			parent:DrawDirectionLine(fwd, false)
+			local dirnorm = plTable.DirNorm or VECTOR_FRONT
+			parent:DrawDirectionLine(dirnorm, true)
+			parent:DrawAngleText(self, intersect, plTable.StartAngle)
 		end
 
 	end
@@ -1028,7 +1040,6 @@ do
 			local toscreen = {}
 			local linetable = self:GetLinePositions(width)
 			local color = self:GetColor()
-			color = Color(color[1], color[2], color[3], color[4])
 
 			for i, v in ipairs(linetable) do
 				local col = color
@@ -1239,7 +1250,6 @@ do
 			if GetConVar("ragdollmover_drawsphere"):GetInt() <= 0 then return end 
 
 			local color = self:GetColor()
-			color = Color(color[1], color[2], color[3], color[4])
 			if yellow then
 				color = COLOR_BRIGHT_YELLOW2
 			end
@@ -1334,6 +1344,14 @@ do
 			return RTable
 		end
 
+		function scalearrow:DrawText(plTable, eyepos, eyeang)
+			local hitpos = self:GetGrabPos(eyepos, eyeang)
+
+			local text = Round(plTable.Entity:GetManipulateBoneScale(plTable.Bone)[self.axistype], 2)
+			local textpos = hitpos:ToScreen()
+			draw.SimpleTextOutlined(text, "RagdollMoverAngleFont", textpos.x + 5, textpos.y, self:GetColor(), TEXT_ALIGN_LEFT, TEXT_ALIGN_BOTTOM, OUTLINE_WIDTH, COLOR_RGMBLACK)
+		end
+
 	end
 
 end
@@ -1417,6 +1435,26 @@ do
 			end
 
 			return RTable
+		end
+
+		function scaleside:DrawText(plTable, eyepos, eyeang)
+			local hitpos = self:GetGrabPos(eyepos, eyeang)
+			local scalevec = plTable.Entity:GetManipulateBoneScale(plTable.Bone)
+			local vec1, vec2
+
+			if self.axistype == 1 then
+				vec1, vec2 = 1, 2
+			elseif self.axistype == 2 then
+				vec1, vec2 = 1, 3
+			else
+				vec1, vec2 = 2, 3
+			end
+
+			local text1 = Round(scalevec[vec1], 2)
+			local text2 = Round(scalevec[vec2], 2)
+			local textpos = hitpos:ToScreen()
+			draw.SimpleTextOutlined(text1, "RagdollMoverAngleFont", textpos.x + 5, textpos.y, self:GetColor(), TEXT_ALIGN_LEFT, TEXT_ALIGN_BOTTOM, OUTLINE_WIDTH, COLOR_RGMBLACK)
+			draw.SimpleTextOutlined(text2, "RagdollMoverAngleFont", textpos.x - 5, textpos.y, self:GetColor(2), TEXT_ALIGN_RIGHT, TEXT_ALIGN_BOTTOM, OUTLINE_WIDTH, COLOR_RGMBLACK)
 		end
 
 	end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -249,12 +249,11 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 		local diff
 		local noscale = plTable.rgmScaleLocks
 		local RecursiveBoneScale
-		local relmove = axis.scalerelativemove
 
 		if axis.smovechildren and childbones then
 			diff = Vector(sc.x / prevscale.x, sc.y / prevscale.y, sc.z / prevscale.z)
 
-			if relmove then
+			if axis.scalerelativemove then
 
 				RecursiveBoneScale = function(ent, bone, scale, diff, ppos, pang, opos, oang, nppos, poschange)
 					if plTable.Bone == bone then

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -246,11 +246,17 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 
 	if axis.scalechildren and not (ent:GetClass() == "ent_advbonemerge") then
 		local scalediff = sc - prevscale
+		local scalediffsqr = scalediff:LengthSqr()
 		local diff
 		local noscale = plTable.rgmScaleLocks
 		local RecursiveBoneScale
+		-- When changing camera view while holding the scale gizmo, the user can achieve some massive scale differences,
+		-- resulting in distorted looking child bones. The magnitude check below ensures this doesn't happen.
+		-- From my experience, a scale difference of at least 1000 was achieved when the camera view and the view differ by
+		-- 90 degrees in orientation
+		local shouldmove = scalediffsqr <= 1000
 
-		if axis.smovechildren and childbones then
+		if axis.smovechildren and childbones and shouldmove then
 			diff = Vector(sc.x / prevscale.x, sc.y / prevscale.y, sc.z / prevscale.z)
 
 			if axis.scalerelativemove then

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -249,11 +249,12 @@ local function rgmDoScale(pl, ent, axis, childbones, bone, sc, prevscale, physmo
 		local diff
 		local noscale = plTable.rgmScaleLocks
 		local RecursiveBoneScale
+		local relmove = axis.scalerelativemove
 
-		if axis.smovechildren and childbones and childbones[bone] then
+		if axis.smovechildren and childbones then
 			diff = Vector(sc.x / prevscale.x, sc.y / prevscale.y, sc.z / prevscale.z)
 
-			if axis.scalerelativemove then
+			if relmove then
 
 				RecursiveBoneScale = function(ent, bone, scale, diff, ppos, pang, opos, oang, nppos, poschange)
 					if plTable.Bone == bone then

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -4995,15 +4995,8 @@ function TOOL:DrawHUD()
 			moveaxis:DrawLines(true, axis.scale, width)
 
 			cam.End()
-			if moveaxis.IsDisc then
-				local intersect = moveaxis:GetGrabPos(eyepos, eyeang)
-				local fwd = (intersect - axis:GetPos())
-				fwd:Normalize()
-				axis:DrawDirectionLine(fwd, false)
-				local dirnorm = plTable.DirNorm or VECTOR_FRONT
-				axis:DrawDirectionLine(dirnorm, true)
-				axis:DrawAngleText(moveaxis, intersect, plTable.StartAngle)
-			end
+
+			if moveaxis.DrawText then moveaxis:DrawText(plTable, eyepos, eyeang) end
 		else
 			cam.Start({type = "3D"})
 			render.SetMaterial(material)


### PR DESCRIPTION
- More optimizations.
- Grabbing onto scaling gizmo will now also show numbers for the current scale on related axises.
- Fixed relative bone scaling not working on physprops with 1 bone.
- Gizmo parts that face the player will now keep their rotation when they are being held - should prevent weird movements when switching view to a camera or back.