### PR TITLE
Save lock data and constrained entity data

### DIFF
--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -397,6 +397,8 @@ function GetOffsetTable(tool, ent, rotate, bonelocks, entlocks)
 	end
 
 	for lockent, pb in pairs(entlocks) do -- getting offsets from physical entities that are locked to our bones
+		if pb.ent ~= ent then continue end
+
 		if not RTable[pb.id].locked then
 			RTable[pb.id].locked = {}
 		end

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -1108,7 +1108,7 @@ hook.Add("OnScreenSizeChanged", "RagdollMoverHUDUpdate", function(_, _, newWidth
 end)
 
 local VERSION_PATH = "rgm/version.txt"
-local RGM_VERSION = "3.0.2"
+local RGM_VERSION = "3.1.0"
 
 -- TODO: Do further testing in multiplayer for cases where the server has a different version of RGM compared to the client
 local function versionMatches(currentVersion, versionPath)

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -593,33 +593,35 @@ function SetOffsets(tool, ent, ostable, sbone, rlocks, plocks, nphysinfo)
 		end
 	end
 
-	for k, v in pairs(ent.rgmIKChains) do
-		if tool:GetClientNumber(DefIKnames[v.type]) ~= 0 then
-			if v.ikhipparent then
-				if not RTable[v.ikhipparent] then RecursiveSetParent(ostable, sbone, ent, rlocks, plocks, RTable, v.ikhipparent, nphysinfo) end
+	if ent.rgmIKChains then
+		for k, v in pairs(ent.rgmIKChains) do
+			if tool:GetClientNumber(DefIKnames[v.type]) ~= 0 then
+				if v.ikhipparent then
+					if not RTable[v.ikhipparent] then RecursiveSetParent(ostable, sbone, ent, rlocks, plocks, RTable, v.ikhipparent, nphysinfo) end
+				end
+	
+				local footdata = ostable[v.foot]
+				if footdata ~= nil and (footdata.parent ~= v.knee and footdata.parent ~= v.hip) and not RTable[footdata.parent] and footdata.lock then 
+					RecursiveSetParent(ostable, sbone, ent, rlocks, plocks, RTable, footdata.parent, nphysinfo)
+				end
+	
+				local RT = ProcessIK(ent, v, sbone, RTable, footdata, nphysinfo)
+				table.Merge(RTable, RT)
 			end
-
-			local footdata = ostable[v.foot]
-			if footdata ~= nil and (footdata.parent ~= v.knee and footdata.parent ~= v.hip) and not RTable[footdata.parent] and footdata.lock then 
-				RecursiveSetParent(ostable, sbone, ent, rlocks, plocks, RTable, footdata.parent, nphysinfo)
-			end
-
-			local RT = ProcessIK(ent, v, sbone, RTable, footdata, nphysinfo)
-			table.Merge(RTable, RT)
 		end
-	end
-
-	for k, v in pairs(ent.rgmIKChains) do -- calculating IKs twice for proper bone locking stuff to IKs, perhaps there is a simpler way to do these
-		if tool:GetClientNumber(DefIKnames[v.type]) ~= 0 then
-
-			local footdata = ostable[v.foot]
-			if not RTable[footdata.parent] then
-				RecursiveSetParent(ostable, sbone, ent, rlocks, plocks, RTable, footdata.parent, nphysinfo)
+	
+		for k, v in pairs(ent.rgmIKChains) do -- calculating IKs twice for proper bone locking stuff to IKs, perhaps there is a simpler way to do these
+			if tool:GetClientNumber(DefIKnames[v.type]) ~= 0 then
+	
+				local footdata = ostable[v.foot]
+				if not RTable[footdata.parent] then
+					RecursiveSetParent(ostable, sbone, ent, rlocks, plocks, RTable, footdata.parent, nphysinfo)
+				end
+	
+				local RT = ProcessIK(ent, v, sbone, RTable, footdata, nphysinfo)
+				table.Merge(RTable, RT)
 			end
-
-			local RT = ProcessIK(ent, v, sbone, RTable, footdata, nphysinfo)
-			table.Merge(RTable, RT)
-		end
+		end	
 	end
 
 	for pb = 0, physcount do

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -4524,6 +4524,42 @@ local function RGMMakeBoneButtonPanel(col)
 	return parentpanel
 end
 
+local function RGMMakeResetLocksPanel(col)
+	local parentpanel = vgui.Create("Panel", col)
+	col:AddItem(parentpanel)
+
+	parentpanel.resetlocks = vgui.Create("DButton", parentpanel) 
+	parentpanel.resetlocks:SetText("#tool.ragdollmover.resetlocks")
+	parentpanel.resetlocks:SetTooltip("#tool.ragdollmover.resetlocks.tooltip")
+	function parentpanel.resetlocks:DoClick() 
+		NetStarter.rgmDedicatedResetLocks()
+			net.WriteBool(false)
+		net.SendToServer()
+	end
+
+	parentpanel.resetalllocks = vgui.Create("DButton", parentpanel) 
+	parentpanel.resetalllocks:SetText("#tool.ragdollmover.resetalllocks")
+	parentpanel.resetalllocks:SetTooltip("#tool.ragdollmover.resetalllocks.tooltip")
+
+	function parentpanel.resetalllocks:DoClick() 
+		NetStarter.rgmDedicatedResetLocks()
+			net.WriteBool(true)
+		net.SendToServer()
+	end
+
+	function parentpanel:PerformLayout(w, h)
+		-- parentpanel.resetlocks:Dock(LEFT)
+		-- parentpanel.resetalllocks:Dock(RIGHT)
+	
+		parentpanel.resetlocks:SetSize(w / 2 - 5, h)
+		parentpanel.resetalllocks:SetSize(w / 2 - 5, h)
+		parentpanel.resetalllocks:SetPos(w / 2 + 5, 0)
+
+	end
+	
+	return parentpanel
+end
+
 local function RGMMakeAngleSnap(col)
 	local parentpanel = vgui.Create("DPanelList", col)
 	parentpanel:EnableHorizontal(false)
@@ -4636,6 +4672,7 @@ function TOOL.BuildCPanel(CPanel)
 		local physmovecheck = CCheckBox(Col4, "#tool.ragdollmover.physmove", "ragdollmover_physmove")
 		physmovecheck:SetToolTip("#tool.ragdollmover.physmovetip")
 		RGMMakeAngleSnap(Col4)
+		RGMMakeResetLocksPanel(Col4) 
 		
 
 		local Col5 = CCol(Col4, "#tool.ragdollmover.scaleoptions", true) 

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -69,6 +69,10 @@ tool.ragdollmover.scale2=Scale Y
 tool.ragdollmover.scale3=Scale Z
 
 tool.ragdollmover.resetallbones=Reset All Bones
+tool.ragdollmover.resetlocks=Reset selected locks
+tool.ragdollmover.resetlocks.tooltip=Remove position, rotation, scale, bones, and constrained locks from the selected entity
+tool.ragdollmover.resetalllocks=Reset all entities' locks
+tool.ragdollmover.resetalllocks.tooltip=Remove locks from all entities other than the selected entity. This is irreversible
 
 tool.ragdollmover.scaleoptions=Scaling Options
 tool.ragdollmover.scalechildren=Scale children bones


### PR DESCRIPTION
- Changed behavior of saving lock data and constrained entity data when switching between entities; instead of resetting locks automatically when switching entities, they stay preserved
- Added manual lock resetting concommands `ragdollmover_resetlocks` and `ragdollmover_resetalllocks`; the former concommand resets locks for the player's selected entity, while the latter resets locks for all entities that the player has added locks to in the past
- Added duplicator and GMod save support for lock data and constrained entity data. Locks such as position, angle, scale, and bones can be duplicated or saved. Constrained entity data (locks between one entity to another entity) can also be duplicated or saved
- Changed entity lock data structure to be keyed per entity, which stores its locked entities, instead of being keyed per lock entity (as in previous versions)