### PR TITLE
InitPostEntity bugfix and further locking improvements

### DIFF
--- a/lua/autorun/client/ragdollmover_client.lua
+++ b/lua/autorun/client/ragdollmover_client.lua
@@ -1,5 +1,5 @@
 
-hook.Add("InitPostEntity", "rgmClientSetup", function()
+hook.Add("rgmInit", "rgmClientSetup", function()
 
 	if ConVarExists("ragdollmover_lockselected") then -- i should use some lua variable instead of console variable so it would reset properly
 		RunConsoleCommand("ragdollmover_lockselected", 0)

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -1139,7 +1139,7 @@ local function showChangelog()
 end
 
 -- When localplayer is valid, check if we should notify the user
-hook.Add("InitPostEntity", "RagdollMoverNotifyOnStart", function()
+hook.Add("rgmInit", "RagdollMoverNotifyOnStart", function()
 	if not versionMatches(RGM_VERSION, VERSION_PATH) then
 		local notice1 = language.GetPhrase("ui.ragdollmover.notice1")
 		local notice2 = language.GetPhrase("ui.ragdollmover.notice2")

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -1139,7 +1139,7 @@ hook.Add("OnScreenSizeChanged", "RagdollMoverHUDUpdate", function(_, _, newWidth
 end)
 
 local VERSION_PATH = "rgm/version.txt"
-local RGM_VERSION = "3.1.0"
+local RGM_VERSION = "3.1.1"
 
 -- TODO: Do further testing in multiplayer for cases where the server has a different version of RGM compared to the client
 local function versionMatches(currentVersion, versionPath)

--- a/lua/autorun/ragdollmover.lua
+++ b/lua/autorun/ragdollmover.lua
@@ -403,27 +403,57 @@ function GetOffsetTable(tool, ent, rotate, bonelocks, entlocks)
 
 	end
 
-	for lockent, pb in pairs(entlocks) do -- getting offsets from physical entities that are locked to our bones
-		if pb.ent ~= ent then continue end
+	if not propragdoll then
+		entlocks = entlocks[ent]
+		for lockent, pb in pairs(entlocks) do -- getting offsets from physical entities that are locked to our bones
+			if not RTable[pb.id].locked then
+				RTable[pb.id].locked = {}
+			end
 
-		if not RTable[pb.id].locked then
-			RTable[pb.id].locked = {}
+			local locktable = {}
+
+			for i=0, lockent:GetPhysicsObjectCount() - 1 do
+				local obj1 = lockent:GetPhysicsObjectNum(i)
+				local obj2 = pb.ent:GetPhysicsObjectNum(propragdoll and 0 or pb.id)
+				local pos1, ang1 = obj1:GetPos(), obj1:GetAngles()
+				local pos2, ang2 = obj2:GetPos(), obj2:GetAngles()
+				local pos3, ang3 = WorldToLocal(pos1, ang1, pos2, ang2)
+				local mov = obj1:IsMoveable()
+
+				locktable[i] = {pos = pos3, ang = ang3, moving = mov, parent = -1}
+			end
+
+			RTable[pb.id].locked[lockent] = locktable
 		end
+	else
+		for lent, lockeddata in pairs(entlocks) do
+			boneid = nil
+			for id, data in pairs(RTable) do
+				if lent == data.ent then boneid = id break end
+			end
 
-		local locktable = {}
+			if not boneid then continue end
+			for lockent, pb in pairs(lockeddata) do -- getting offsets from physical entities that are locked to our bones
+				if not RTable[boneid].locked then
+					RTable[boneid].locked = {}
+				end
 
-		for i=0, lockent:GetPhysicsObjectCount() - 1 do
-			local obj1 = lockent:GetPhysicsObjectNum(i)
-			local obj2 = pb.ent:GetPhysicsObjectNum(propragdoll and 0 or pb.id)
-			local pos1, ang1 = obj1:GetPos(), obj1:GetAngles()
-			local pos2, ang2 = obj2:GetPos(), obj2:GetAngles()
-			local pos3, ang3 = WorldToLocal(pos1, ang1, pos2, ang2)
-			local mov = obj1:IsMoveable()
+				local locktable = {}
 
-			locktable[i] = {pos = pos3, ang = ang3, moving = mov, parent = -1}
+				for i=0, lockent:GetPhysicsObjectCount() - 1 do
+					local obj1 = lockent:GetPhysicsObjectNum(i)
+					local obj2 = pb.ent:GetPhysicsObjectNum(propragdoll and 0 or boneid)
+					local pos1, ang1 = obj1:GetPos(), obj1:GetAngles()
+					local pos2, ang2 = obj2:GetPos(), obj2:GetAngles()
+					local pos3, ang3 = WorldToLocal(pos1, ang1, pos2, ang2)
+					local mov = obj1:IsMoveable()
+
+					locktable[i] = {pos = pos3, ang = ang3, moving = mov, parent = -1}
+				end
+
+				RTable[boneid].locked[lockent] = locktable
+			end
 		end
-
-		RTable[pb.id].locked[lockent] = locktable
 	end
 
 	return RTable
@@ -432,6 +462,7 @@ end
 function GetNPOffsetTable(tool, ent, rotate, nphysinfo, nphyschildren, bonelocks, entlocks)
 	local RTable = {}
 	local physcount = ent:GetPhysicsObjectCount() - 1
+	local entlocks = entlocks[ent]
 
 	if not ent.rgmIKChains then
 		CreateDefaultIKs(tool, ent)

--- a/lua/autorun/ragdollmover_meta.lua
+++ b/lua/autorun/ragdollmover_meta.lua
@@ -219,24 +219,31 @@ local pl = LocalPlayer()
 
 hook.Remove("Think", "rgmClientBuffer") -- for hotloading
 
-hook.Add("InitPostEntity", "rgmMetaInitPlayer", function()
+hook.Add("Think", "rgmMetaCheckIfInit", function()
 	pl = LocalPlayer()
-	if not RAGDOLLMOVER[pl] then RAGDOLLMOVER[pl] = {} end
 
-	hook.Add("Think", "rgmClientBuffer", function()
-		if IsValid(pl) and not RAGDOLLMOVER[pl] then RAGDOLLMOVER[pl] = {} end
+	if IsValid(pl) then
+		if not RAGDOLLMOVER[pl] then RAGDOLLMOVER[pl] = {} end
 
-		if next(buffer) then
-			for name, value in pairs(buffer) do
-				if not istable(value) then
-					RAGDOLLMOVER[pl][name] = value
-				else
-					RAGDOLLMOVER[pl][name] = (Entity(value[1]))
+		hook.Run("rgmInit") -- Using custom hook instead of InitPostEntity, as some addons may do what gmod wiki tells not to do, and return some value in a hook, breaking the whole thing in the process. Thanks, random gmod addons!
+
+		hook.Add("Think", "rgmClientBuffer", function()
+			if IsValid(pl) and not RAGDOLLMOVER[pl] then RAGDOLLMOVER[pl] = {} end
+
+			if next(buffer) then
+				for name, value in pairs(buffer) do
+					if not istable(value) then
+						RAGDOLLMOVER[pl][name] = value
+					else
+						RAGDOLLMOVER[pl][name] = (Entity(value[1]))
+					end
 				end
+				buffer = {}
 			end
-			buffer = {}
-		end
-	end)
+		end)
+
+		hook.Remove("Think", "rgmMetaCheckIfInit")
+	end
 end)
 
 end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -2781,7 +2781,7 @@ if IsValid(pl) then
 	RAGDOLLMOVER[pl].PlViewEnt = 0
 end
 
-hook.Add("InitPostEntity", "rgmSetPlayer", function()
+hook.Add("rgmInit", "rgmSetPlayer", function()
 	pl = LocalPlayer()
 	if not RAGDOLLMOVER[pl] then RAGDOLLMOVER[pl] = {} end
 	RAGDOLLMOVER[pl].PlViewEnt = 0

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -706,12 +706,12 @@ local function deserializeConstraints(entLockData, entity, newEnts)
 
 	if not newEnts then
 		for lockent, lockinfo in pairs(entLockData) do
-			local infoent = lockinfo.ent and Entity(lockinfo.ent) or entity
+			local infoent = lockinfo.ent and newEnts[lockinfo.ent] or entity
 			newLockData[Entity(lockent)] = {id = lockinfo.id, ent = infoent}
 		end
 	else
 		for lockent, lockinfo in pairs(entLockData) do
-			local infoent = lockinfo.ent and Entity(lockinfo.ent) or entity
+			local infoent = lockinfo.ent and newEnts[lockinfo.ent] or entity
 			newLockData[newEnts[lockent]] = {id = lockinfo.id, ent = infoent}
 		end
 	end

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -706,11 +706,13 @@ local function deserializeConstraints(entLockData, entity, newEnts)
 
 	if not newEnts then
 		for lockent, lockinfo in pairs(entLockData) do
-			newLockData[Entity(lockent)] = {id = lockinfo.id, ent = Entity(lockinfo.ent)}
+			local infoent = lockinfo.ent and Entity(lockinfo.ent) or entity
+			newLockData[Entity(lockent)] = {id = lockinfo.id, ent = infoent}
 		end
 	else
 		for lockent, lockinfo in pairs(entLockData) do
-			newLockData[newEnts[lockent]] = {id = lockinfo.id, ent = newEnts[lockinfo.ent]}
+			local infoent = lockinfo.ent and Entity(lockinfo.ent) or entity
+			newLockData[newEnts[lockent]] = {id = lockinfo.id, ent = infoent}
 		end
 	end
 

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -706,7 +706,7 @@ local function deserializeConstraints(entLockData, entity, newEnts)
 
 	if not newEnts then
 		for lockent, lockinfo in pairs(entLockData) do
-			local infoent = lockinfo.ent and newEnts[lockinfo.ent] or entity
+			local infoent = lockinfo.ent and lockinfo.ent or entity
 			newLockData[Entity(lockent)] = {id = lockinfo.id, ent = infoent}
 		end
 	else

--- a/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
@@ -13,11 +13,24 @@ local PROPRAGDOLL_CLEARED = 5
 local function ClearPropRagdoll(ent, keepmodifier)
 	if SERVER then
 		for id, pl in ipairs(player.GetAll()) do
-			if RAGDOLLMOVER[pl] and RAGDOLLMOVER[pl].Entity == ent then
-				RAGDOLLMOVER[pl].Entity = nil
-				net.Start("RAGDOLLMOVER")
-					net.WriteUInt(0, 4)
-				net.Send(pl)
+			plTable = RAGDOLLMOVER[pl]
+			if plTable then
+				if plTable.Entity == ent then
+					plTable.Entity = nil
+					net.Start("RAGDOLLMOVER")
+						net.WriteUInt(0, 4)
+					net.Send(pl)
+				end
+
+				plTable.rgmPosLocks[ent] = {}
+				plTable.rgmAngLocks[ent] = {}
+				plTable.rgmScaleLocks[ent] = {}
+				plTable.rgmBoneLocks[ent] = {}
+				if plTable.rgmEntLocks[ent] and next(plTable.rgmEntLocks[ent]) then
+					for lckent, locktable in pairs(plTable.rgmEntLocks[ent]) do
+						locktable.id = 0
+					end
+				end
 			end
 		end
 	end

--- a/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
@@ -67,11 +67,11 @@ duplicator.RegisterEntityModifier("Ragdoll Mover Prop Ragdoll", function(pl, ent
 	ent.rgmPRoffset = data.offset
 	ent.rgmPRaoffset = data.aoffset -- a stands for angle
 
-	ent.rgmOldPostEntityPaste = ent.PostEntityPaste
+	local rgmOldPostEntityPaste = ent.PostEntityPaste
 
 	ent.PostEntityPaste = function(self, pl, ent, crtEnts)
-		if ent.rgmOldPostEntityPaste then
-			ent:rgmOldPostEntityPaste(pl, ent, crtEnts)
+		if rgmOldPostEntityPaste then
+			rgmOldPostEntityPaste(ent, pl, ent, crtEnts)
 		end
 
 		if not ent.rgmPRenttoid or not ent.rgmPRidtoent then return end

--- a/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
+++ b/lua/weapons/gmod_tool/stools/ragmover_propragdoll.lua
@@ -43,6 +43,7 @@ local function ClearPropRagdoll(ent, keepmodifier)
 
 	if not keepmodifier then
 		duplicator.ClearEntityModifier(ent, "Ragdoll Mover Prop Ragdoll")
+		duplicator.ClearEntityModifier(ent, "Ragdoll Mover IK Dupe Data")
 	end
 end
 


### PR DESCRIPTION
- Fixed error related to relying on InitPostEntity hook for initializing variables.
- Added entity and bone locking support to Prop Ragdolls.
- Various optimizations and fixes for bone locks.
- IK data from IK chains tool now gets saved into entities for duping.
- Fixed Prop Ragdoll data not being saved in a dupe if original Prop Ragdoll was deleted during game session.