### PR TITLE
Fix for being stuck in selection mode

### DIFF
--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -2218,6 +2218,7 @@ function TOOL:Deploy()
 	end
 end
 
+-- KNOWN ISSUE: In Singleplayer, this is not called in CLIENT realm upon death (prediction behavior)
 function TOOL:Holster()
 	if SERVER then
 		local pl = self:GetOwner()
@@ -2226,7 +2227,10 @@ function TOOL:Holster()
 		for ent, lockeddata in pairs(plTable.rgmEntLocks) do
 			rgmDupeLocks(pl, ent, getDupeData(plTable, ent), true)
 		end
-	end
+	else
+        -- In case you were in mouse cursor mode (e.g. radial menu)
+        gui.EnableScreenClicker(false)
+    end
 end
 
 local function EntityFilter(ent, tool)


### PR DESCRIPTION
Dying or switching weapons after/upon entering radial menu will no longer have you stuck in cursor mode. EXCEPTION: Dying while in radial menu in Singleplayer